### PR TITLE
feat(banner): Banner component for 1.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to Bear UI will be documented in this file.
 ### Added
 
 - **`AppShell`** — app chrome layout with header, navbar, main, optional aside/footer, collapsible navbar, and sticky header/footer options.
+- **`Banner`** — full-width announcement strip with severity, sticky/static position, dismissible, action slot, and shared live-region a11y.
 
 ---
 

--- a/portal/src/App.tsx
+++ b/portal/src/App.tsx
@@ -296,6 +296,7 @@ const FormKitPage = lazy(() => import('./pages/templates/FormKit'));
 const AuthKitPage = lazy(() => import('./pages/templates/AuthKit'));
 const PageHeaderPage = lazy(() => import('./pages/components/PageHeader'));
 const AppShellPage = lazy(() => import('./pages/components/AppShell'));
+const BannerPage = lazy(() => import('./pages/components/Banner'));
 
 // Customization
 const CustomizationOverviewPage = lazy(() => import('./pages/customization/Overview'));
@@ -645,6 +646,7 @@ function PortalLayout({
                 <Route path="/templates/auth" element={<AuthKitPage />} />
                 <Route path="/components/page-header" element={<PageHeaderPage />} />
                 <Route path="/components/app-shell" element={<AppShellPage />} />
+                <Route path="/components/banner" element={<BannerPage />} />
                 <Route path="/store" element={<StorePage />} />
                 
                 {/* Guides */}

--- a/portal/src/constants/navigation.const.ts
+++ b/portal/src/constants/navigation.const.ts
@@ -232,6 +232,7 @@ export const NAVIGATION: NavGroup[] = [
         label: 'Feedback',
         children: [
           { path: '/components/alert', label: 'Alert' },
+          { path: '/components/banner', label: 'Banner', badge: 'New' },
           { path: '/components/toast', label: 'Toast' },
           { path: '/components/snackbar', label: 'Snackbar', badge: 'New' },
           { path: '/components/notification-center', label: 'NotificationCenter' },

--- a/portal/src/pages/components/Banner/Banner.tsx
+++ b/portal/src/pages/components/Banner/Banner.tsx
@@ -1,0 +1,96 @@
+import { FC, useState } from 'react';
+import { Banner, Button } from '@forgedevstack/bear';
+import { CodeBlock } from '@/components/CodeBlock';
+import { ComponentPreview } from '@/components/ComponentPreview';
+
+const BannerPage: FC = () => {
+  const [open, setOpen] = useState(true);
+
+  return (
+    <div className="fade-in">
+      <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-4">Banner</h1>
+      <p className="text-gray-600 dark:text-gray-400 mb-8">
+        Full-width announcement strip for version notices, incidents, and promos. Supports severity,
+        sticky placement, dismiss, and optional actions.
+      </p>
+      <div className="mb-8">
+        <CodeBlock
+          language="tsx"
+          showLineNumbers={false}
+          code={`import { Banner, Button } from '@forgedevstack/bear';`}
+        />
+      </div>
+      <ComponentPreview
+        title="Severity"
+        description="Info, success, warning, and error tones with dual-mode tokens."
+        code={`<Banner severity="info" title="Bear 1.2.8">
+  New Banner and AppShell components are in progress.
+</Banner>`}
+      >
+        <div className="flex flex-col gap-3 w-full">
+          <Banner severity="info" title="Info">
+            Release notes and non-urgent updates.
+          </Banner>
+          <Banner severity="success" title="Success">
+            Deploy completed successfully.
+          </Banner>
+          <Banner severity="warning" title="Warning">
+            Maintenance window starts at 22:00 UTC.
+          </Banner>
+          <Banner severity="error" title="Error">
+            Payment provider is degraded.
+          </Banner>
+        </div>
+      </ComponentPreview>
+      <ComponentPreview
+        title="Dismissible + action"
+        description="Controlled open state with action button and dismiss."
+        code={`<Banner
+  severity="info"
+  dismissible
+  open={open}
+  onDismiss={() => setOpen(false)}
+  action={<Button size="sm">Learn more</Button>}
+>
+  Bear v1.2.8 sprint is underway.
+</Banner>`}
+      >
+        <div className="flex flex-col gap-3 w-full">
+          {open ? (
+            <Banner
+              severity="info"
+              title="Announcement"
+              dismissible
+              open={open}
+              onDismiss={() => setOpen(false)}
+              action={
+                <Button size="sm" variant="outline">
+                  Learn more
+                </Button>
+              }
+            >
+              Bear v1.2.8 sprint is underway on release/1.2.8.
+            </Banner>
+          ) : (
+            <Button size="sm" onClick={() => setOpen(true)}>
+              Show banner
+            </Button>
+          )}
+        </div>
+      </ComponentPreview>
+      <ComponentPreview
+        title="Sticky"
+        description="Sticks to the top of the scroll container."
+        code={`<Banner severity="warning" position="sticky" title="Sticky banner">
+  Remains visible while scrolling.
+</Banner>`}
+      >
+        <Banner severity="warning" position="sticky" title="Sticky banner">
+          Remains visible while scrolling.
+        </Banner>
+      </ComponentPreview>
+    </div>
+  );
+};
+
+export default BannerPage;

--- a/portal/src/pages/components/Banner/index.ts
+++ b/portal/src/pages/components/Banner/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Banner';

--- a/src/components/Banner/Banner.const.ts
+++ b/src/components/Banner/Banner.const.ts
@@ -1,0 +1,52 @@
+import type { BannerPosition, BannerSeverity, BannerTranslations } from './Banner.types';
+
+export const BANNER_ROOT_CLASS = 'Bear-Banner';
+
+export const BANNER_DEFAULT_SEVERITY: BannerSeverity = 'info';
+
+export const BANNER_DEFAULT_POSITION: BannerPosition = 'static';
+
+export const BANNER_DEFAULT_DISMISSIBLE = false;
+
+export const BANNER_DEFAULT_FULL_WIDTH = true;
+
+export const BANNER_DEFAULT_SHOW_ICON = true;
+
+export const BANNER_DEFAULT_OPEN = true;
+
+export const BANNER_DEFAULT_TRANSLATIONS: BannerTranslations = {
+  dismissLabel: 'Dismiss',
+};
+
+export const BANNER_BASE_CLASSES =
+  'bear-flex bear-items-center bear-gap-3 bear-px-4 bear-py-3 bear-border-b bear-border-[var(--bear-border-default)]';
+
+export const BANNER_FULL_WIDTH_CLASS = 'bear-w-full';
+
+export const BANNER_POSITION_CLASSES: Record<BannerPosition, string> = {
+  static: '',
+  sticky: 'bear-sticky bear-top-0 bear-z-40',
+};
+
+export const BANNER_SEVERITY_CLASSES: Record<BannerSeverity, string> = {
+  info: 'bear-bg-[var(--bear-info-50,#eff6ff)] bear-text-[var(--bear-info-800,#1e40af)]',
+  success: 'bear-bg-[var(--bear-success-50,#f0fdf4)] bear-text-[var(--bear-success-800,#166534)]',
+  warning: 'bear-bg-[var(--bear-warning-50,#fffbeb)] bear-text-[var(--bear-warning-800,#92400e)]',
+  error: 'bear-bg-[var(--bear-danger-50,#fef2f2)] bear-text-[var(--bear-danger-800,#991b1b)]',
+};
+
+export const BANNER_ICON_CLASS = `${BANNER_ROOT_CLASS}__icon bear-flex-shrink-0 bear-w-5 bear-h-5`;
+
+export const BANNER_CONTENT_CLASS = `${BANNER_ROOT_CLASS}__content bear-flex-1 bear-min-w-0 bear-text-sm`;
+
+export const BANNER_TITLE_CLASS = `${BANNER_ROOT_CLASS}__title bear-font-semibold bear-mb-0.5`;
+
+export const BANNER_MESSAGE_CLASS = `${BANNER_ROOT_CLASS}__message`;
+
+export const BANNER_ACTION_CLASS = `${BANNER_ROOT_CLASS}__action bear-flex-shrink-0`;
+
+export const BANNER_DISMISS_CLASS = `${BANNER_ROOT_CLASS}__dismiss bear-flex-shrink-0`;
+
+export const BANNER_ICON_SIZE = 20;
+
+export const BANNER_ICON_STROKE_WIDTH = 2;

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -1,0 +1,116 @@
+import { FC, useState, type ReactNode } from 'react';
+import type { BannerProps, BannerSeverity } from './Banner.types';
+import {
+  BANNER_ACTION_CLASS,
+  BANNER_BASE_CLASSES,
+  BANNER_CONTENT_CLASS,
+  BANNER_DEFAULT_DISMISSIBLE,
+  BANNER_DEFAULT_FULL_WIDTH,
+  BANNER_DEFAULT_OPEN,
+  BANNER_DEFAULT_POSITION,
+  BANNER_DEFAULT_SEVERITY,
+  BANNER_DEFAULT_SHOW_ICON,
+  BANNER_DEFAULT_TRANSLATIONS,
+  BANNER_DISMISS_CLASS,
+  BANNER_FULL_WIDTH_CLASS,
+  BANNER_ICON_CLASS,
+  BANNER_MESSAGE_CLASS,
+  BANNER_POSITION_CLASSES,
+  BANNER_ROOT_CLASS,
+  BANNER_SEVERITY_CLASSES,
+  BANNER_TITLE_CLASS,
+} from './Banner.const';
+import {
+  BannerErrorSvg,
+  BannerInfoSvg,
+  BannerSuccessSvg,
+  BannerWarningSvg,
+} from './helpers';
+import { CloseButton } from '../CloseButton';
+import { cn, getBearLiveRegionProps, resolveBearId, useBearId } from '@utils';
+
+const DEFAULT_ICONS: Record<BannerSeverity, ReactNode> = {
+  info: <BannerInfoSvg />,
+  success: <BannerSuccessSvg />,
+  warning: <BannerWarningSvg />,
+  error: <BannerErrorSvg />,
+};
+
+export const Banner: FC<BannerProps> = (props) => {
+  const {
+    severity = BANNER_DEFAULT_SEVERITY,
+    title,
+    children,
+    action,
+    icon = BANNER_DEFAULT_SHOW_ICON,
+    dismissible = BANNER_DEFAULT_DISMISSIBLE,
+    onDismiss,
+    open,
+    position = BANNER_DEFAULT_POSITION,
+    fullWidth = BANNER_DEFAULT_FULL_WIDTH,
+    translations,
+    className,
+    id,
+    testId,
+    ...rest
+  } = props;
+
+  const [internalOpen, setInternalOpen] = useState(BANNER_DEFAULT_OPEN);
+  const isOpen = open ?? internalOpen;
+  const generatedId = useBearId('Banner');
+  const domId = resolveBearId(id, generatedId);
+  const dismissLabel = translations?.dismissLabel ?? BANNER_DEFAULT_TRANSLATIONS.dismissLabel;
+  const liveRegionProps = getBearLiveRegionProps(severity);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const handleDismiss = () => {
+    if (open === undefined) {
+      setInternalOpen(false);
+    }
+    onDismiss?.();
+  };
+
+  const renderIcon = () => {
+    if (icon === false) {
+      return null;
+    }
+    if (icon !== true) {
+      return icon;
+    }
+    return DEFAULT_ICONS[severity];
+  };
+
+  const iconNode = renderIcon();
+
+  return (
+    <div
+      {...rest}
+      {...liveRegionProps}
+      id={domId}
+      data-testid={testId}
+      className={cn(
+        BANNER_ROOT_CLASS,
+        BANNER_BASE_CLASSES,
+        BANNER_SEVERITY_CLASSES[severity],
+        BANNER_POSITION_CLASSES[position],
+        fullWidth && BANNER_FULL_WIDTH_CLASS,
+        className
+      )}
+    >
+      {iconNode && <span className={BANNER_ICON_CLASS}>{iconNode}</span>}
+      <div className={BANNER_CONTENT_CLASS}>
+        {title && <div className={BANNER_TITLE_CLASS}>{title}</div>}
+        {children && <div className={BANNER_MESSAGE_CLASS}>{children}</div>}
+      </div>
+      {action && <div className={BANNER_ACTION_CLASS}>{action}</div>}
+      {dismissible && (
+        <div className={BANNER_DISMISS_CLASS}>
+          <CloseButton size="sm" onClick={handleDismiss} aria-label={dismissLabel} />
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/Banner/Banner.types.ts
+++ b/src/components/Banner/Banner.types.ts
@@ -1,0 +1,25 @@
+import type { HTMLAttributes, ReactNode } from 'react';
+
+export type BannerSeverity = 'info' | 'success' | 'warning' | 'error';
+
+export type BannerPosition = 'static' | 'sticky';
+
+export interface BannerTranslations {
+  dismissLabel: string;
+}
+
+export interface BannerProps extends Omit<HTMLAttributes<HTMLDivElement>, 'title'> {
+  severity?: BannerSeverity;
+  title?: ReactNode;
+  children?: ReactNode;
+  action?: ReactNode;
+  icon?: boolean | ReactNode;
+  dismissible?: boolean;
+  onDismiss?: () => void;
+  open?: boolean;
+  position?: BannerPosition;
+  fullWidth?: boolean;
+  translations?: Partial<BannerTranslations>;
+  id?: string;
+  testId?: string;
+}

--- a/src/components/Banner/helpers/BannerErrorSvg.tsx
+++ b/src/components/Banner/helpers/BannerErrorSvg.tsx
@@ -1,0 +1,18 @@
+import { FC } from 'react';
+import { BANNER_ICON_SIZE, BANNER_ICON_STROKE_WIDTH } from '../Banner.const';
+
+export const BannerErrorSvg: FC = () => (
+  <svg
+    width={BANNER_ICON_SIZE}
+    height={BANNER_ICON_SIZE}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={BANNER_ICON_STROKE_WIDTH}
+    aria-hidden="true"
+  >
+    <circle cx="12" cy="12" r="10" />
+    <line x1="15" y1="9" x2="9" y2="15" />
+    <line x1="9" y1="9" x2="15" y2="15" />
+  </svg>
+);

--- a/src/components/Banner/helpers/BannerInfoSvg.tsx
+++ b/src/components/Banner/helpers/BannerInfoSvg.tsx
@@ -1,0 +1,18 @@
+import { FC } from 'react';
+import { BANNER_ICON_SIZE, BANNER_ICON_STROKE_WIDTH } from '../Banner.const';
+
+export const BannerInfoSvg: FC = () => (
+  <svg
+    width={BANNER_ICON_SIZE}
+    height={BANNER_ICON_SIZE}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={BANNER_ICON_STROKE_WIDTH}
+    aria-hidden="true"
+  >
+    <circle cx="12" cy="12" r="10" />
+    <line x1="12" y1="16" x2="12" y2="12" />
+    <line x1="12" y1="8" x2="12.01" y2="8" />
+  </svg>
+);

--- a/src/components/Banner/helpers/BannerSuccessSvg.tsx
+++ b/src/components/Banner/helpers/BannerSuccessSvg.tsx
@@ -1,0 +1,17 @@
+import { FC } from 'react';
+import { BANNER_ICON_SIZE, BANNER_ICON_STROKE_WIDTH } from '../Banner.const';
+
+export const BannerSuccessSvg: FC = () => (
+  <svg
+    width={BANNER_ICON_SIZE}
+    height={BANNER_ICON_SIZE}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={BANNER_ICON_STROKE_WIDTH}
+    aria-hidden="true"
+  >
+    <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+    <polyline points="22 4 12 14.01 9 11.01" />
+  </svg>
+);

--- a/src/components/Banner/helpers/BannerWarningSvg.tsx
+++ b/src/components/Banner/helpers/BannerWarningSvg.tsx
@@ -1,0 +1,18 @@
+import { FC } from 'react';
+import { BANNER_ICON_SIZE, BANNER_ICON_STROKE_WIDTH } from '../Banner.const';
+
+export const BannerWarningSvg: FC = () => (
+  <svg
+    width={BANNER_ICON_SIZE}
+    height={BANNER_ICON_SIZE}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={BANNER_ICON_STROKE_WIDTH}
+    aria-hidden="true"
+  >
+    <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+    <line x1="12" y1="9" x2="12" y2="13" />
+    <line x1="12" y1="17" x2="12.01" y2="17" />
+  </svg>
+);

--- a/src/components/Banner/helpers/index.ts
+++ b/src/components/Banner/helpers/index.ts
@@ -1,0 +1,4 @@
+export { BannerInfoSvg } from './BannerInfoSvg';
+export { BannerSuccessSvg } from './BannerSuccessSvg';
+export { BannerWarningSvg } from './BannerWarningSvg';
+export { BannerErrorSvg } from './BannerErrorSvg';

--- a/src/components/Banner/index.ts
+++ b/src/components/Banner/index.ts
@@ -1,0 +1,7 @@
+export { Banner } from './Banner';
+export type {
+  BannerProps,
+  BannerSeverity,
+  BannerPosition,
+  BannerTranslations,
+} from './Banner.types';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -229,6 +229,14 @@ export type { PageHeaderProps } from './PageHeader';
 export { AppShell } from './AppShell';
 export type { AppShellProps, AppShellNavbarWidth } from './AppShell';
 
+export { Banner } from './Banner';
+export type {
+  BannerProps,
+  BannerSeverity,
+  BannerPosition,
+  BannerTranslations,
+} from './Banner';
+
 export { Image } from './Image';
 export type { ImageProps } from './Image';
 


### PR DESCRIPTION
## Summary
- Add `Banner` with severity, sticky/static, dismissible, action slot, and shared live-region props
- Portal page at `/components/banner` + nav entry
- Changelog stub under 1.2.8

## Jira / GitHub
- FORGE-8 · https://github.com/yaghobieh/bear/issues/44

## Test plan
- [ ] `npm run build` passes
- [ ] Portal `/components/banner` demos severities + dismiss
- [ ] Light/dark mode readable


Made with [Cursor](https://cursor.com)