### PR TITLE
feat(appshell): AppShell layout for 1.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Bear UI will be documented in this file.
 
+## [1.2.8] - Unreleased
+
+### Added
+
+- **`AppShell`** — app chrome layout with header, navbar, main, optional aside/footer, collapsible navbar, and sticky header/footer options.
+
+---
+
 ## [1.2.7] - 2026-08-01
 
 ### Added

--- a/portal/src/App.tsx
+++ b/portal/src/App.tsx
@@ -295,6 +295,7 @@ const DashboardKitPage = lazy(() => import('./pages/templates/DashboardKit'));
 const FormKitPage = lazy(() => import('./pages/templates/FormKit'));
 const AuthKitPage = lazy(() => import('./pages/templates/AuthKit'));
 const PageHeaderPage = lazy(() => import('./pages/components/PageHeader'));
+const AppShellPage = lazy(() => import('./pages/components/AppShell'));
 
 // Customization
 const CustomizationOverviewPage = lazy(() => import('./pages/customization/Overview'));
@@ -643,6 +644,7 @@ function PortalLayout({
                 <Route path="/templates/form" element={<FormKitPage />} />
                 <Route path="/templates/auth" element={<AuthKitPage />} />
                 <Route path="/components/page-header" element={<PageHeaderPage />} />
+                <Route path="/components/app-shell" element={<AppShellPage />} />
                 <Route path="/store" element={<StorePage />} />
                 
                 {/* Guides */}

--- a/portal/src/constants/navigation.const.ts
+++ b/portal/src/constants/navigation.const.ts
@@ -93,6 +93,7 @@ export const NAVIGATION: NavGroup[] = [
         label: 'Page Layout',
         children: [
           { path: '/components/app-bar', label: 'AppBar' },
+          { path: '/components/app-shell', label: 'AppShell', badge: 'New' },
           { path: '/components/sidebar', label: 'Sidebar' },
           { path: '/components/page-header', label: 'PageHeader', badge: 'New' },
           { path: '/components/dock', label: 'Dock' },

--- a/portal/src/pages/components/AppShell/AppShell.tsx
+++ b/portal/src/pages/components/AppShell/AppShell.tsx
@@ -1,0 +1,86 @@
+import { FC, useState } from 'react';
+import {
+  AppBar,
+  AppShell,
+  Button,
+  PageHeader,
+  Sidebar,
+  Typography,
+} from '@forgedevstack/bear';
+import { CodeBlock } from '@/components/CodeBlock';
+import { ComponentPreview } from '@/components/ComponentPreview';
+
+const AppShellPage: FC = () => {
+  const [collapsed, setCollapsed] = useState(false);
+
+  return (
+    <div className="fade-in">
+      <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-4">AppShell</h1>
+      <p className="text-gray-600 dark:text-gray-400 mb-8">
+        App chrome layout with header, navbar, main, optional aside, and footer slots. Built for
+        dashboard and admin shells.
+      </p>
+      <div className="mb-8">
+        <CodeBlock
+          language="tsx"
+          showLineNumbers={false}
+          code={`import { AppShell, AppBar, Sidebar, PageHeader } from '@forgedevstack/bear';`}
+        />
+      </div>
+      <ComponentPreview
+        title="Basic shell"
+        description="Header + navbar + main content."
+        code={`<AppShell
+  header={<AppBar leftContent="Forge Ops" dense />}
+  navbar={<Sidebar items={items} activeItemId="overview" />}
+>
+  <PageHeader title="Overview" />
+</AppShell>`}
+      >
+        <div className="w-full border border-gray-200 dark:border-zinc-700 rounded-lg overflow-hidden h-[360px]">
+          <AppShell
+            className="h-full"
+            header={
+              <AppBar
+                dense
+                leftContent={<Typography className="font-semibold">Forge Ops</Typography>}
+                rightContent={
+                  <Button size="sm" variant="outline" onClick={() => setCollapsed((v) => !v)}>
+                    {collapsed ? 'Expand nav' : 'Collapse nav'}
+                  </Button>
+                }
+              />
+            }
+            navbar={
+              <Sidebar
+                items={[
+                  { id: 'overview', label: 'Overview' },
+                  { id: 'reports', label: 'Reports' },
+                  { id: 'settings', label: 'Settings' },
+                ]}
+                activeItemId="overview"
+              />
+            }
+            navbarCollapsed={collapsed}
+            footer={
+              <div className="px-4 py-2 text-sm text-gray-500 dark:text-zinc-400">
+                © ForgeStack
+              </div>
+            }
+          >
+            <PageHeader
+              title="Overview"
+              description="AppShell composes AppBar + Sidebar + page content."
+              actions={<Button size="sm">New</Button>}
+            />
+            <Typography variant="body2" className="mt-4">
+              Main content area scrolls independently of the sticky header.
+            </Typography>
+          </AppShell>
+        </div>
+      </ComponentPreview>
+    </div>
+  );
+};
+
+export default AppShellPage;

--- a/portal/src/pages/components/AppShell/index.ts
+++ b/portal/src/pages/components/AppShell/index.ts
@@ -1,0 +1,1 @@
+export { default } from './AppShell';

--- a/src/components/AppShell/AppShell.const.ts
+++ b/src/components/AppShell/AppShell.const.ts
@@ -1,0 +1,42 @@
+import type { AppShellNavbarWidth } from './AppShell.types';
+
+export const APP_SHELL_ROOT_CLASS = 'Bear-AppShell';
+
+export const APP_SHELL_DEFAULT_NAVBAR_COLLAPSED = false;
+
+export const APP_SHELL_DEFAULT_NAVBAR_WIDTH: AppShellNavbarWidth = 'md';
+
+export const APP_SHELL_DEFAULT_STICKY_HEADER = true;
+
+export const APP_SHELL_DEFAULT_STICKY_FOOTER = false;
+
+export const APP_SHELL_DEFAULT_PADDING = true;
+
+export const APP_SHELL_BASE_CLASSES =
+  'bear-flex bear-flex-col bear-min-h-0 bear-w-full bear-bg-[var(--bear-bg-primary)] bear-text-[var(--bear-text-primary)]';
+
+export const APP_SHELL_BODY_CLASSES = `${APP_SHELL_ROOT_CLASS}__body bear-flex bear-flex-1 bear-min-h-0 bear-w-full`;
+
+export const APP_SHELL_HEADER_CLASSES = `${APP_SHELL_ROOT_CLASS}__header bear-w-full bear-z-30 bear-bg-[var(--bear-bg-primary)] bear-border-b bear-border-[var(--bear-border-default)]`;
+
+export const APP_SHELL_HEADER_STICKY_CLASS = 'bear-sticky bear-top-0';
+
+export const APP_SHELL_NAVBAR_BASE_CLASSES = `${APP_SHELL_ROOT_CLASS}__navbar bear-flex-shrink-0 bear-overflow-y-auto bear-border-e bear-border-[var(--bear-border-default)] bear-bg-[var(--bear-bg-secondary)]`;
+
+export const APP_SHELL_NAVBAR_WIDTH_CLASSES: Record<AppShellNavbarWidth, string> = {
+  sm: 'bear-w-56',
+  md: 'bear-w-64',
+  lg: 'bear-w-72',
+};
+
+export const APP_SHELL_NAVBAR_COLLAPSED_CLASS = 'bear-w-0 bear-overflow-hidden bear-border-e-0';
+
+export const APP_SHELL_MAIN_CLASSES = `${APP_SHELL_ROOT_CLASS}__main bear-flex-1 bear-min-w-0 bear-overflow-auto`;
+
+export const APP_SHELL_MAIN_PADDING_CLASS = 'bear-p-4 md:bear-p-6';
+
+export const APP_SHELL_ASIDE_CLASSES = `${APP_SHELL_ROOT_CLASS}__aside bear-w-64 bear-flex-shrink-0 bear-overflow-y-auto bear-border-s bear-border-[var(--bear-border-default)] bear-bg-[var(--bear-bg-secondary)] bear-hidden lg:bear-block`;
+
+export const APP_SHELL_FOOTER_CLASSES = `${APP_SHELL_ROOT_CLASS}__footer bear-w-full bear-z-20 bear-bg-[var(--bear-bg-primary)] bear-border-t bear-border-[var(--bear-border-default)]`;
+
+export const APP_SHELL_FOOTER_STICKY_CLASS = 'bear-sticky bear-bottom-0';

--- a/src/components/AppShell/AppShell.tsx
+++ b/src/components/AppShell/AppShell.tsx
@@ -1,0 +1,99 @@
+import { FC } from 'react';
+import type { AppShellProps } from './AppShell.types';
+import {
+  APP_SHELL_ASIDE_CLASSES,
+  APP_SHELL_BASE_CLASSES,
+  APP_SHELL_BODY_CLASSES,
+  APP_SHELL_DEFAULT_NAVBAR_COLLAPSED,
+  APP_SHELL_DEFAULT_NAVBAR_WIDTH,
+  APP_SHELL_DEFAULT_PADDING,
+  APP_SHELL_DEFAULT_STICKY_FOOTER,
+  APP_SHELL_DEFAULT_STICKY_HEADER,
+  APP_SHELL_FOOTER_CLASSES,
+  APP_SHELL_FOOTER_STICKY_CLASS,
+  APP_SHELL_HEADER_CLASSES,
+  APP_SHELL_HEADER_STICKY_CLASS,
+  APP_SHELL_MAIN_CLASSES,
+  APP_SHELL_MAIN_PADDING_CLASS,
+  APP_SHELL_NAVBAR_BASE_CLASSES,
+  APP_SHELL_NAVBAR_COLLAPSED_CLASS,
+  APP_SHELL_NAVBAR_WIDTH_CLASSES,
+  APP_SHELL_ROOT_CLASS,
+} from './AppShell.const';
+import { cn, resolveBearId, useBearId } from '@utils';
+
+export const AppShell: FC<AppShellProps> = (props) => {
+  const {
+    header,
+    navbar,
+    aside,
+    footer,
+    children,
+    navbarCollapsed = APP_SHELL_DEFAULT_NAVBAR_COLLAPSED,
+    navbarWidth = APP_SHELL_DEFAULT_NAVBAR_WIDTH,
+    stickyHeader = APP_SHELL_DEFAULT_STICKY_HEADER,
+    stickyFooter = APP_SHELL_DEFAULT_STICKY_FOOTER,
+    padding = APP_SHELL_DEFAULT_PADDING,
+    className,
+    id,
+    testId,
+    ...rest
+  } = props;
+
+  const generatedId = useBearId('AppShell');
+  const domId = resolveBearId(id, generatedId);
+
+  return (
+    <div
+      {...rest}
+      id={domId}
+      data-testid={testId}
+      className={cn(APP_SHELL_ROOT_CLASS, APP_SHELL_BASE_CLASSES, className)}
+    >
+      {header && (
+        <div
+          className={cn(
+            APP_SHELL_HEADER_CLASSES,
+            stickyHeader && APP_SHELL_HEADER_STICKY_CLASS
+          )}
+        >
+          {header}
+        </div>
+      )}
+      <div className={APP_SHELL_BODY_CLASSES}>
+        {navbar !== undefined && (
+          <aside
+            className={cn(
+              APP_SHELL_NAVBAR_BASE_CLASSES,
+              navbarCollapsed
+                ? APP_SHELL_NAVBAR_COLLAPSED_CLASS
+                : APP_SHELL_NAVBAR_WIDTH_CLASSES[navbarWidth]
+            )}
+            aria-hidden={navbarCollapsed || undefined}
+          >
+            {navbar}
+          </aside>
+        )}
+        <main
+          className={cn(
+            APP_SHELL_MAIN_CLASSES,
+            padding && APP_SHELL_MAIN_PADDING_CLASS
+          )}
+        >
+          {children}
+        </main>
+        {aside && <aside className={APP_SHELL_ASIDE_CLASSES}>{aside}</aside>}
+      </div>
+      {footer && (
+        <div
+          className={cn(
+            APP_SHELL_FOOTER_CLASSES,
+            stickyFooter && APP_SHELL_FOOTER_STICKY_CLASS
+          )}
+        >
+          {footer}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/AppShell/AppShell.types.ts
+++ b/src/components/AppShell/AppShell.types.ts
@@ -1,0 +1,18 @@
+import type { HTMLAttributes, ReactNode } from 'react';
+
+export type AppShellNavbarWidth = 'sm' | 'md' | 'lg';
+
+export interface AppShellProps extends HTMLAttributes<HTMLDivElement> {
+  header?: ReactNode;
+  navbar?: ReactNode;
+  aside?: ReactNode;
+  footer?: ReactNode;
+  children?: ReactNode;
+  navbarCollapsed?: boolean;
+  navbarWidth?: AppShellNavbarWidth;
+  stickyHeader?: boolean;
+  stickyFooter?: boolean;
+  padding?: boolean;
+  id?: string;
+  testId?: string;
+}

--- a/src/components/AppShell/index.ts
+++ b/src/components/AppShell/index.ts
@@ -1,0 +1,2 @@
+export { AppShell } from './AppShell';
+export type { AppShellProps, AppShellNavbarWidth } from './AppShell.types';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -226,6 +226,9 @@ export type { EmptyStateProps } from './EmptyState';
 export { PageHeader } from './PageHeader';
 export type { PageHeaderProps } from './PageHeader';
 
+export { AppShell } from './AppShell';
+export type { AppShellProps, AppShellNavbarWidth } from './AppShell';
+
 export { Image } from './Image';
 export type { ImageProps } from './Image';
 


### PR DESCRIPTION
## Summary
- Add `AppShell` with header, navbar, main, optional aside/footer
- Collapsible navbar, sticky header/footer, density-friendly padding
- Portal page at `/components/app-shell` + nav entry
- Changelog stub under 1.2.8

## Jira / GitHub
- FORGE-11 · https://github.com/yaghobieh/bear/issues/43
- Linear: GAT-34

## Test plan
- [ ] `npm run build` passes
- [ ] Portal `/components/app-shell` collapse toggle works
- [ ] Light/dark surfaces readable


Made with [Cursor](https://cursor.com)