### PR TITLE
docs(portal): Ink and Calendar companion banners for 1.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to Bear UI will be documented in this file.
 
-## [Unreleased]
+## [1.2.9] - 2026-08-14
 
 ### Fixed
 
@@ -12,6 +12,8 @@ All notable changes to Bear UI will be documented in this file.
 ### Portal
 
 - Dashboard + form kits: PropsTable sections; dashboard StatCards use distinct colors; form Stepper is clickable.
+- **RichEditor** companion banner linking to Ink (`inkforgejs.com` + npm).
+- **Calendar** companion banner linking to Forge Calendar (`forgecalendar.com` + npm).
 
 ## [1.2.8] - 2026-08-08
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@forgedevstack/bear",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@forgedevstack/bear",
-      "version": "1.2.8",
+      "version": "1.2.9",
       "license": "MIT",
       "dependencies": {
         "@forgedevstack/anvil": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forgedevstack/bear",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "Strong, reliable React UI components. AeroCraft-powered, zero config required. The protective force of ForgeStack.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/portal/src/App.tsx
+++ b/portal/src/App.tsx
@@ -8,8 +8,8 @@ import { DocPageNav } from './components/DocPageNav';
 import { RouteSEO } from './components/RouteSEO';
 
 const BANNER_CONFIG = {
-  id: 'bear-1.2.8',
-  message: 'Bear v1.2.8 — AppShell, Banner, and portal docs for the 1.2.8 release.',
+  id: 'bear-1.2.9',
+  message: 'Bear v1.2.9 — kit light-mode fixes, RichEditor → Ink, Calendar → Forge Calendar.',
   link: '/whats-new',
   linkText: "See what's new",
 };

--- a/portal/src/constants/changelog.const.ts
+++ b/portal/src/constants/changelog.const.ts
@@ -10,6 +10,28 @@ export interface ChangelogEntry {
 
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
+    version: '1.2.9',
+    date: 'August 14, 2026',
+    tag: 'patch',
+    sections: [
+      {
+        title: 'Fixed',
+        items: [
+          'StatCard bear-* prefixes so dashboard kit works in light mode',
+          'Stepper active/pending contrast in light mode',
+        ],
+      },
+      {
+        title: 'Portal',
+        items: [
+          'Kit PropsTables; clickable form Stepper',
+          'RichEditor banner → Ink',
+          'Calendar banner → Forge Calendar',
+        ],
+      },
+    ],
+  },
+  {
     version: '1.2.8',
     date: 'August 8, 2026',
     tag: 'patch',

--- a/portal/src/constants/navigation.const.ts
+++ b/portal/src/constants/navigation.const.ts
@@ -17,7 +17,7 @@ export interface NavGroup {
   icon?: string;
 }
 
-export const BEAR_VERSION = '1.2.8';
+export const BEAR_VERSION = '1.2.9';
 
 /** Main Bear UI repository */
 export const GITHUB_URL = 'https://github.com/yaghobieh/bear';
@@ -533,7 +533,8 @@ export const NAVIGATION: NavGroup[] = [
 ];
 
 export const VERSIONS = [
-  { value: '1.2.8', label: 'v1.2.8 (current)' },
+  { value: '1.2.9', label: 'v1.2.9 (current)' },
+  { value: '1.2.8', label: 'v1.2.8' },
   { value: '1.2.7', label: 'v1.2.7' },
   { value: '1.2.6', label: 'v1.2.6' },
   { value: '1.2.5', label: 'v1.2.5' },

--- a/portal/src/constants/topbar.const.ts
+++ b/portal/src/constants/topbar.const.ts
@@ -24,4 +24,4 @@ export const VERSION_POPUP_FEATURES = [
 ];
 
 export const VERSION_POPUP_DESCRIPTION =
-  'v1.2.8 — AppShell layout primitive, Banner announcement strip, portal pages, and release polish on top of 1.2.7 PageHeader / density / template kits.';
+  'v1.2.9 — StatCard/Stepper light-mode, kit PropsTables, RichEditor → Ink banner, Calendar → Forge Calendar banner.';

--- a/portal/src/pages/components/Calendar.tsx
+++ b/portal/src/pages/components/Calendar.tsx
@@ -2,7 +2,7 @@ import { FC, useState } from 'react';
 import { CodeBlock } from '@/components/CodeBlock';
 import { ComponentPreview } from '@/components/ComponentPreview';
 import { LinesOfCode } from '@/components/LinesOfCode';
-import { Calendar } from '@forgedevstack/bear';
+import { Calendar, Card, BearIcons } from '@forgedevstack/bear';
 
 const CalendarPage: FC = () => {
   const [viewDate, setViewDate] = useState(new Date());
@@ -14,9 +14,46 @@ const CalendarPage: FC = () => {
         <h1 className="text-3xl font-bold text-gray-900 dark:text-white">Calendar</h1>
         <LinesOfCode lines={180} />
       </div>
-      <p className="text-gray-600 dark:text-gray-400 mb-8">
+      <p className="text-gray-600 dark:text-gray-400 mb-6">
         Standalone calendar with customizable slots. Use with DatePicker or alone for date display and selection.
       </p>
+
+      <Card className="mb-8 p-4 bg-gradient-to-r from-teal-50 to-emerald-50 dark:from-teal-900/20 dark:to-emerald-900/20 border-teal-200 dark:border-teal-800">
+        <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
+          <div className="flex items-start gap-3">
+            <BearIcons.CalendarIcon size={24} className="text-teal-600 flex-shrink-0 mt-1" />
+            <div>
+              <h3 className="font-semibold text-gray-900 dark:text-white mb-1">
+                ForgeStack Scheduler: @forgedevstack/calendar
+              </h3>
+              <p className="text-sm text-gray-600 dark:text-gray-400">
+                Forge Calendar is the dedicated scheduler for ForgeStack — month, week, day, and agenda views with timed events.
+                Bear Calendar stays the date-picker widget.
+              </p>
+            </div>
+          </div>
+          <div className="flex flex-col sm:flex-row gap-2 flex-shrink-0">
+            <a
+              href="https://www.npmjs.com/package/@forgedevstack/calendar"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-teal-600 hover:bg-teal-700 text-white text-sm font-medium transition-colors"
+            >
+              <BearIcons.PackageIcon size={16} />
+              npm
+            </a>
+            <a
+              href="https://forgecalendar.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-gray-800 hover:bg-gray-900 dark:bg-gray-700 dark:hover:bg-gray-600 text-white text-sm font-medium transition-colors"
+            >
+              <BearIcons.GlobeIcon size={16} />
+              forgecalendar.com
+            </a>
+          </div>
+        </div>
+      </Card>
 
       <section className="mb-12">
         <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-4">Import</h2>

--- a/portal/src/pages/components/RichEditor.tsx
+++ b/portal/src/pages/components/RichEditor.tsx
@@ -2,7 +2,7 @@ import { FC, useState } from 'react';
 import { CodeBlock } from '@/components/CodeBlock';
 import { ComponentPreview } from '@/components/ComponentPreview';
 import { LinesOfCode } from '@/components/LinesOfCode';
-import { RichEditor, Button, Card } from '@forgedevstack/bear';
+import { RichEditor, Button, Card, BearIcons } from '@forgedevstack/bear';
 
 const RichEditorPage: FC = () => {
   const [basicValue, setBasicValue] = useState('<p>Start editing here...</p>');
@@ -17,9 +17,46 @@ const RichEditorPage: FC = () => {
         <h1 className="text-3xl font-bold text-gray-900 dark:text-white">RichEditor</h1>
         <LinesOfCode lines={500} />
       </div>
-      <p className="text-gray-600 dark:text-gray-400 mb-8">
+      <p className="text-gray-600 dark:text-gray-400 mb-6">
         A full-featured WYSIWYG rich text editor with formatting toolbar, heading styles, colors, lists, links, and image paste support.
       </p>
+
+      <Card className="mb-8 p-4 bg-gradient-to-r from-pink-50 to-purple-50 dark:from-pink-900/20 dark:to-purple-900/20 border-pink-200 dark:border-pink-800">
+        <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
+          <div className="flex items-start gap-3">
+            <BearIcons.EditIcon size={24} className="text-pink-500 flex-shrink-0 mt-1" />
+            <div>
+              <h3 className="font-semibold text-gray-900 dark:text-white mb-1">
+                ForgeStack Editor: @forgedevstack/ink
+              </h3>
+              <p className="text-sm text-gray-600 dark:text-gray-400">
+                Ink is the dedicated rich text editor for ForgeStack — tables, track changes, comments, block handles, and pluggable AI.
+                Fully typed and designed to work with Bear UI. Bear RichEditor stays the lightweight in-library editor.
+              </p>
+            </div>
+          </div>
+          <div className="flex flex-col sm:flex-row gap-2 flex-shrink-0">
+            <a
+              href="https://www.npmjs.com/package/@forgedevstack/ink"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-pink-500 hover:bg-pink-600 text-white text-sm font-medium transition-colors"
+            >
+              <BearIcons.PackageIcon size={16} />
+              npm
+            </a>
+            <a
+              href="https://inkforgejs.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-gray-800 hover:bg-gray-900 dark:bg-gray-700 dark:hover:bg-gray-600 text-white text-sm font-medium transition-colors"
+            >
+              <BearIcons.GlobeIcon size={16} />
+              inkforgejs.com
+            </a>
+          </div>
+        </div>
+      </Card>
 
       <section className="mb-12">
         <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-4">Import</h2>


### PR DESCRIPTION
## Summary
- Bump `@forgedevstack/bear` to **1.2.9**
- Portal banners: RichEditor → Ink, Calendar → Forge Calendar
- Changelog / nav / topbar version strings for 1.2.9

## Test plan
- [x] Pre-commit: ESLint, tsc, Playwright smoke
- [ ] Merge into `release/1.2.9`, then `release/1.2.9` → `main` to publish


Made with [Cursor](https://cursor.com)