### PR TITLE
release: Bear 1.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Bear UI will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- **`StatCard`** — replaced bare Tailwind utilities with `bear-*` prefixed classes + `Bear-StatCard` BEM so gradients/layout ship in the library CSS (dashboard kit light mode).
+- **`Stepper`** — active/pending indicators use `bear-bg-primary-*` / dual-mode tokens so step numbers stay readable in light mode.
+
+### Portal
+
+- Dashboard + form kits: PropsTable sections; dashboard StatCards use distinct colors; form Stepper is clickable.
+
 ## [1.2.8] - 2026-08-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to Bear UI will be documented in this file.
 
-## [Unreleased]
+## [1.2.9] - 2026-08-14
 
 ### Fixed
 
@@ -12,6 +12,8 @@ All notable changes to Bear UI will be documented in this file.
 ### Portal
 
 - Dashboard + form kits: PropsTable sections; dashboard StatCards use distinct colors; form Stepper is clickable.
+- **RichEditor** companion banner linking to Ink (`inkforgejs.com` + npm).
+- **Calendar** companion banner linking to Forge Calendar (`forgecalendar.com` + npm).
 
 ## [1.2.8] - 2026-08-08
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@forgedevstack/bear",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@forgedevstack/bear",
-      "version": "1.2.8",
+      "version": "1.2.9",
       "license": "MIT",
       "dependencies": {
         "@forgedevstack/anvil": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forgedevstack/bear",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "Strong, reliable React UI components. AeroCraft-powered, zero config required. The protective force of ForgeStack.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/portal/src/App.tsx
+++ b/portal/src/App.tsx
@@ -8,8 +8,8 @@ import { DocPageNav } from './components/DocPageNav';
 import { RouteSEO } from './components/RouteSEO';
 
 const BANNER_CONFIG = {
-  id: 'bear-1.2.8',
-  message: 'Bear v1.2.8 — AppShell, Banner, and portal docs for the 1.2.8 release.',
+  id: 'bear-1.2.9',
+  message: 'Bear v1.2.9 — kit light-mode fixes, RichEditor → Ink, Calendar → Forge Calendar.',
   link: '/whats-new',
   linkText: "See what's new",
 };

--- a/portal/src/constants/changelog.const.ts
+++ b/portal/src/constants/changelog.const.ts
@@ -10,6 +10,28 @@ export interface ChangelogEntry {
 
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
+    version: '1.2.9',
+    date: 'August 14, 2026',
+    tag: 'patch',
+    sections: [
+      {
+        title: 'Fixed',
+        items: [
+          'StatCard bear-* prefixes so dashboard kit works in light mode',
+          'Stepper active/pending contrast in light mode',
+        ],
+      },
+      {
+        title: 'Portal',
+        items: [
+          'Kit PropsTables; clickable form Stepper',
+          'RichEditor banner → Ink',
+          'Calendar banner → Forge Calendar',
+        ],
+      },
+    ],
+  },
+  {
     version: '1.2.8',
     date: 'August 8, 2026',
     tag: 'patch',

--- a/portal/src/constants/navigation.const.ts
+++ b/portal/src/constants/navigation.const.ts
@@ -17,7 +17,7 @@ export interface NavGroup {
   icon?: string;
 }
 
-export const BEAR_VERSION = '1.2.8';
+export const BEAR_VERSION = '1.2.9';
 
 /** Main Bear UI repository */
 export const GITHUB_URL = 'https://github.com/yaghobieh/bear';
@@ -533,7 +533,8 @@ export const NAVIGATION: NavGroup[] = [
 ];
 
 export const VERSIONS = [
-  { value: '1.2.8', label: 'v1.2.8 (current)' },
+  { value: '1.2.9', label: 'v1.2.9 (current)' },
+  { value: '1.2.8', label: 'v1.2.8' },
   { value: '1.2.7', label: 'v1.2.7' },
   { value: '1.2.6', label: 'v1.2.6' },
   { value: '1.2.5', label: 'v1.2.5' },

--- a/portal/src/constants/topbar.const.ts
+++ b/portal/src/constants/topbar.const.ts
@@ -24,4 +24,4 @@ export const VERSION_POPUP_FEATURES = [
 ];
 
 export const VERSION_POPUP_DESCRIPTION =
-  'v1.2.8 — AppShell layout primitive, Banner announcement strip, portal pages, and release polish on top of 1.2.7 PageHeader / density / template kits.';
+  'v1.2.9 — StatCard/Stepper light-mode, kit PropsTables, RichEditor → Ink banner, Calendar → Forge Calendar banner.';

--- a/portal/src/pages/components/Calendar.tsx
+++ b/portal/src/pages/components/Calendar.tsx
@@ -2,7 +2,7 @@ import { FC, useState } from 'react';
 import { CodeBlock } from '@/components/CodeBlock';
 import { ComponentPreview } from '@/components/ComponentPreview';
 import { LinesOfCode } from '@/components/LinesOfCode';
-import { Calendar } from '@forgedevstack/bear';
+import { Calendar, Card, BearIcons } from '@forgedevstack/bear';
 
 const CalendarPage: FC = () => {
   const [viewDate, setViewDate] = useState(new Date());
@@ -14,9 +14,46 @@ const CalendarPage: FC = () => {
         <h1 className="text-3xl font-bold text-gray-900 dark:text-white">Calendar</h1>
         <LinesOfCode lines={180} />
       </div>
-      <p className="text-gray-600 dark:text-gray-400 mb-8">
+      <p className="text-gray-600 dark:text-gray-400 mb-6">
         Standalone calendar with customizable slots. Use with DatePicker or alone for date display and selection.
       </p>
+
+      <Card className="mb-8 p-4 bg-gradient-to-r from-teal-50 to-emerald-50 dark:from-teal-900/20 dark:to-emerald-900/20 border-teal-200 dark:border-teal-800">
+        <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
+          <div className="flex items-start gap-3">
+            <BearIcons.CalendarIcon size={24} className="text-teal-600 flex-shrink-0 mt-1" />
+            <div>
+              <h3 className="font-semibold text-gray-900 dark:text-white mb-1">
+                ForgeStack Scheduler: @forgedevstack/calendar
+              </h3>
+              <p className="text-sm text-gray-600 dark:text-gray-400">
+                Forge Calendar is the dedicated scheduler for ForgeStack — month, week, day, and agenda views with timed events.
+                Bear Calendar stays the date-picker widget.
+              </p>
+            </div>
+          </div>
+          <div className="flex flex-col sm:flex-row gap-2 flex-shrink-0">
+            <a
+              href="https://www.npmjs.com/package/@forgedevstack/calendar"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-teal-600 hover:bg-teal-700 text-white text-sm font-medium transition-colors"
+            >
+              <BearIcons.PackageIcon size={16} />
+              npm
+            </a>
+            <a
+              href="https://forgecalendar.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-gray-800 hover:bg-gray-900 dark:bg-gray-700 dark:hover:bg-gray-600 text-white text-sm font-medium transition-colors"
+            >
+              <BearIcons.GlobeIcon size={16} />
+              forgecalendar.com
+            </a>
+          </div>
+        </div>
+      </Card>
 
       <section className="mb-12">
         <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-4">Import</h2>

--- a/portal/src/pages/components/RichEditor.tsx
+++ b/portal/src/pages/components/RichEditor.tsx
@@ -2,7 +2,7 @@ import { FC, useState } from 'react';
 import { CodeBlock } from '@/components/CodeBlock';
 import { ComponentPreview } from '@/components/ComponentPreview';
 import { LinesOfCode } from '@/components/LinesOfCode';
-import { RichEditor, Button, Card } from '@forgedevstack/bear';
+import { RichEditor, Button, Card, BearIcons } from '@forgedevstack/bear';
 
 const RichEditorPage: FC = () => {
   const [basicValue, setBasicValue] = useState('<p>Start editing here...</p>');
@@ -17,9 +17,46 @@ const RichEditorPage: FC = () => {
         <h1 className="text-3xl font-bold text-gray-900 dark:text-white">RichEditor</h1>
         <LinesOfCode lines={500} />
       </div>
-      <p className="text-gray-600 dark:text-gray-400 mb-8">
+      <p className="text-gray-600 dark:text-gray-400 mb-6">
         A full-featured WYSIWYG rich text editor with formatting toolbar, heading styles, colors, lists, links, and image paste support.
       </p>
+
+      <Card className="mb-8 p-4 bg-gradient-to-r from-pink-50 to-purple-50 dark:from-pink-900/20 dark:to-purple-900/20 border-pink-200 dark:border-pink-800">
+        <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
+          <div className="flex items-start gap-3">
+            <BearIcons.EditIcon size={24} className="text-pink-500 flex-shrink-0 mt-1" />
+            <div>
+              <h3 className="font-semibold text-gray-900 dark:text-white mb-1">
+                ForgeStack Editor: @forgedevstack/ink
+              </h3>
+              <p className="text-sm text-gray-600 dark:text-gray-400">
+                Ink is the dedicated rich text editor for ForgeStack — tables, track changes, comments, block handles, and pluggable AI.
+                Fully typed and designed to work with Bear UI. Bear RichEditor stays the lightweight in-library editor.
+              </p>
+            </div>
+          </div>
+          <div className="flex flex-col sm:flex-row gap-2 flex-shrink-0">
+            <a
+              href="https://www.npmjs.com/package/@forgedevstack/ink"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-pink-500 hover:bg-pink-600 text-white text-sm font-medium transition-colors"
+            >
+              <BearIcons.PackageIcon size={16} />
+              npm
+            </a>
+            <a
+              href="https://inkforgejs.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-gray-800 hover:bg-gray-900 dark:bg-gray-700 dark:hover:bg-gray-600 text-white text-sm font-medium transition-colors"
+            >
+              <BearIcons.GlobeIcon size={16} />
+              inkforgejs.com
+            </a>
+          </div>
+        </div>
+      </Card>
 
       <section className="mb-12">
         <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-4">Import</h2>

--- a/portal/src/pages/templates/DashboardKit.const.ts
+++ b/portal/src/pages/templates/DashboardKit.const.ts
@@ -1,0 +1,18 @@
+import type { PropRow } from '@/components/PropsTable';
+
+export const DASHBOARD_KIT_STAT_CARD_PROPS: PropRow[] = [
+  { name: 'title', type: 'string', description: 'Stat label above the value' },
+  { name: 'value', type: 'string | number', description: 'Primary metric value' },
+  { name: 'color', type: 'string', default: "'#6366f1'", description: 'Hex color for the gradient surface' },
+  { name: 'icon', type: 'ReactNode', description: 'Optional icon inside the action button' },
+  { name: 'onClick', type: '() => void', description: 'Makes the card interactive and shows View All' },
+  { name: 'id', type: 'string', description: 'DOM id — Bear-StatCard-* when omitted' },
+  { name: 'testId', type: 'string', description: 'data-testid for tests' },
+  { name: 'className', type: 'string', description: 'Additional classes on the root' },
+];
+
+export const DASHBOARD_STAT_COLORS = {
+  users: '#6366f1',
+  revenue: '#059669',
+  latency: '#d97706',
+} as const;

--- a/portal/src/pages/templates/DashboardKit.tsx
+++ b/portal/src/pages/templates/DashboardKit.tsx
@@ -13,6 +13,8 @@ import {
 import { usePortalLanguage } from '@/hooks/usePortalLanguage';
 import { PORTAL_TEXT } from '@/constants/portal-i18n.const';
 import { CodeBlock } from '@/components/CodeBlock';
+import { PropsTable } from '@/components/PropsTable';
+import { DASHBOARD_KIT_STAT_CARD_PROPS, DASHBOARD_STAT_COLORS } from './DashboardKit.const';
 
 const DashboardKitPage: FC = () => {
   const { language } = usePortalLanguage();
@@ -28,7 +30,7 @@ const DashboardKitPage: FC = () => {
           code={`import { AppBar, PageHeader, Sidebar, StatCard, Card } from '@forgedevstack/bear';`}
         />
       </div>
-      <Card variant="outlined" padding="none" className="overflow-hidden">
+      <Card variant="outlined" padding="none" className="overflow-hidden mb-10">
         <AppBar dense leftContent={<Typography className="font-semibold">Forge Ops</Typography>} />
         <Flex>
           <Sidebar
@@ -39,16 +41,28 @@ const DashboardKitPage: FC = () => {
             activeItemId="overview"
             className="w-56 min-h-[280px]"
           />
-          <div className="flex-1 p-6 space-y-4">
+          <div className="flex-1 p-6 space-y-4 bg-[var(--bear-bg-primary)]">
             <PageHeader
               title={t.templateDashboardTitle}
               description={t.templateDashboardDesc}
               actions={<Button size="sm">{t.templatePrimaryAction}</Button>}
             />
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-              <StatCard title={t.templateStatUsers} value="12.4k" />
-              <StatCard title={t.templateStatRevenue} value="$84k" />
-              <StatCard title={t.templateStatLatency} value="128ms" />
+              <StatCard
+                title={t.templateStatUsers}
+                value="12.4k"
+                color={DASHBOARD_STAT_COLORS.users}
+              />
+              <StatCard
+                title={t.templateStatRevenue}
+                value="$84k"
+                color={DASHBOARD_STAT_COLORS.revenue}
+              />
+              <StatCard
+                title={t.templateStatLatency}
+                value="128ms"
+                color={DASHBOARD_STAT_COLORS.latency}
+              />
             </div>
             <CardBody>
               <Typography variant="body2">{t.templateDashboardBody}</Typography>
@@ -56,6 +70,7 @@ const DashboardKitPage: FC = () => {
           </div>
         </Flex>
       </Card>
+      <PropsTable title="StatCard props" rows={DASHBOARD_KIT_STAT_CARD_PROPS} />
     </div>
   );
 };

--- a/portal/src/pages/templates/FormKit.const.ts
+++ b/portal/src/pages/templates/FormKit.const.ts
@@ -1,0 +1,14 @@
+import type { PropRow } from '@/components/PropsTable';
+
+export const FORM_KIT_STEPPER_PROPS: PropRow[] = [
+  { name: 'steps', type: 'Step[]', description: 'Step definitions (label, description, status, …)' },
+  { name: 'activeStep', type: 'number', description: 'Zero-based index of the current step' },
+  { name: 'onStepClick', type: '(index: number) => void', description: 'Fired when a step is clicked (if clickable)' },
+  { name: 'orientation', type: "'horizontal' | 'vertical'", default: "'horizontal'", description: 'Layout direction' },
+  { name: 'size', type: "'sm' | 'md' | 'lg'", default: "'md'", description: 'Indicator and label size' },
+  { name: 'showNumbers', type: 'boolean', default: 'true', description: 'Show step numbers in indicators' },
+  { name: 'clickable', type: 'boolean', default: 'false', description: 'Allow navigating by clicking steps' },
+  { name: 'showConnectors', type: 'boolean', default: 'true', description: 'Draw connectors between steps' },
+  { name: 'testId', type: 'string', description: 'data-testid for tests' },
+  { name: 'className', type: 'string', description: 'Additional classes on the root' },
+];

--- a/portal/src/pages/templates/FormKit.tsx
+++ b/portal/src/pages/templates/FormKit.tsx
@@ -12,6 +12,8 @@ import {
 import { usePortalLanguage } from '@/hooks/usePortalLanguage';
 import { PORTAL_TEXT } from '@/constants/portal-i18n.const';
 import { CodeBlock } from '@/components/CodeBlock';
+import { PropsTable } from '@/components/PropsTable';
+import { FORM_KIT_STEPPER_PROPS } from './FormKit.const';
 
 const FormKitPage: FC = () => {
   const { language } = usePortalLanguage();
@@ -22,10 +24,18 @@ const FormKitPage: FC = () => {
   return (
     <div className="fade-in">
       <PageHeader title={t.templateFormTitle} description={t.templateFormDesc} />
-      <div className="mb-8"><CodeBlock language="tsx" showLineNumbers={false} code={`import { FormControl, Input, Select, Stepper, Button } from '@forgedevstack/bear';`} /></div>
-      <Card variant="outlined" padding="lg" className="max-w-2xl space-y-6">
+      <div className="mb-8">
+        <CodeBlock
+          language="tsx"
+          showLineNumbers={false}
+          code={`import { FormControl, Input, Select, Stepper, Button } from '@forgedevstack/bear';`}
+        />
+      </div>
+      <Card variant="outlined" padding="lg" className="max-w-2xl space-y-6 mb-10">
         <Stepper
           activeStep={step}
+          clickable
+          onStepClick={setStep}
           steps={[
             { label: t.templateStepProfile },
             { label: t.templateStepAccess },
@@ -55,6 +65,7 @@ const FormKitPage: FC = () => {
           </Button>
         </Flex>
       </Card>
+      <PropsTable title="Stepper props" rows={FORM_KIT_STEPPER_PROPS} />
     </div>
   );
 };

--- a/src/components/StatCard/StatCard.const.ts
+++ b/src/components/StatCard/StatCard.const.ts
@@ -1,1 +1,25 @@
-export const S_T_A_T_C_A_R_D_ROOT_CLASS = 'Bear-StatCard';
+export const STAT_CARD_ROOT_CLASS = 'Bear-StatCard';
+
+export const STAT_CARD_BASE_CLASSES =
+  'bear-relative bear-overflow-hidden bear-rounded-2xl bear-p-6 bear-transition-transform hover:bear-scale-105 bear-cursor-pointer bear-border bear-border-[var(--bear-border-default)]';
+
+export const STAT_CARD_DECORATION_CLASS =
+  'Bear-StatCard__decoration bear-absolute bear-top-0 bear-right-0 bear-w-32 bear-h-32 -bear-mr-8 -bear-mt-8 bear-rounded-full bear-opacity-20 bear-bg-white';
+
+export const STAT_CARD_BODY_CLASS = 'Bear-StatCard__body bear-relative bear-z-10';
+
+export const STAT_CARD_TITLE_CLASS =
+  'Bear-StatCard__title bear-text-white/80 bear-text-sm bear-font-medium bear-mb-1';
+
+export const STAT_CARD_VALUE_CLASS =
+  'Bear-StatCard__value bear-text-white bear-text-3xl bear-font-bold bear-mb-4';
+
+export const STAT_CARD_ACTION_CLASS =
+  'Bear-StatCard__action bear-flex bear-items-center bear-gap-2 bear-px-4 bear-py-1.5 bear-bg-white/20 hover:bear-bg-white/30 bear-rounded-full bear-text-white bear-text-sm bear-font-medium bear-transition-colors bear-border-0';
+
+export const DEFAULT_STAT_CARD_COLOR = '#6366f1';
+
+export const STAT_CARD_GRADIENT_START_ALPHA = 'dd';
+export const STAT_CARD_GRADIENT_END_ALPHA = '99';
+
+export const DEFAULT_STAT_CARD_ACTION_LABEL = 'View All';

--- a/src/components/StatCard/StatCard.tsx
+++ b/src/components/StatCard/StatCard.tsx
@@ -1,46 +1,64 @@
 import { FC } from 'react';
-import {cn } from '@utils';
-import { StatCardProps } from './StatCard.types';
+import { cn, resolveBearId, useBearId } from '@utils';
+import type { StatCardProps } from './StatCard.types';
+import {
+  DEFAULT_STAT_CARD_ACTION_LABEL,
+  DEFAULT_STAT_CARD_COLOR,
+  STAT_CARD_ACTION_CLASS,
+  STAT_CARD_BASE_CLASSES,
+  STAT_CARD_BODY_CLASS,
+  STAT_CARD_DECORATION_CLASS,
+  STAT_CARD_GRADIENT_END_ALPHA,
+  STAT_CARD_GRADIENT_START_ALPHA,
+  STAT_CARD_ROOT_CLASS,
+  STAT_CARD_TITLE_CLASS,
+  STAT_CARD_VALUE_CLASS,
+} from './StatCard.const';
 
-/**
- * StatCard Component
- * A colorful statistics card with gradient background
- */
 export const StatCard: FC<StatCardProps> = ({
-
   title,
   value,
-  color = '#6366f1',
+  color = DEFAULT_STAT_CARD_COLOR,
   icon,
   onClick,
   className,
+  id,
+  testId,
   ...props
 }) => {
+  const generatedId = useBearId('StatCard');
+  const domId = resolveBearId(id, generatedId);
+  const background = `linear-gradient(135deg, ${color}${STAT_CARD_GRADIENT_START_ALPHA}, ${color}${STAT_CARD_GRADIENT_END_ALPHA})`;
 
   return (
     <div
-      className={cn(
-        'relative overflow-hidden rounded-2xl p-6 transition-transform hover:scale-105 cursor-pointer',
-        className
-      )}
-      style={{ background: `linear-gradient(135deg, ${color}dd, ${color}99)` }}
+      id={domId}
+      data-testid={testId}
+      role={onClick ? 'button' : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      className={cn(STAT_CARD_ROOT_CLASS, STAT_CARD_BASE_CLASSES, className)}
+      style={{ background }}
       onClick={onClick}
+      onKeyDown={(event) => {
+        if (!onClick) return;
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          onClick();
+        }
+      }}
       {...props}
     >
-      {/* Background decoration */}
-      <div className="absolute top-0 right-0 w-32 h-32 -mr-8 -mt-8 rounded-full opacity-20 bg-white" />
-      
-      <div className="relative z-10">
-        <p className="text-white/80 text-sm font-medium mb-1">{title}</p>
-        <p className="text-white text-3xl font-bold mb-4">{value}</p>
+      <div className={STAT_CARD_DECORATION_CLASS} aria-hidden />
+      <div className={STAT_CARD_BODY_CLASS}>
+        <p className={STAT_CARD_TITLE_CLASS}>{title}</p>
+        <p className={STAT_CARD_VALUE_CLASS}>{value}</p>
         {onClick && (
-          <button className="flex items-center gap-2 px-4 py-1.5 bg-white/20 hover:bg-white/30 rounded-full text-white text-sm font-medium transition-colors">
+          <button type="button" className={STAT_CARD_ACTION_CLASS}>
             {icon}
-            View All
+            {DEFAULT_STAT_CARD_ACTION_LABEL}
           </button>
         )}
       </div>
     </div>
   );
 };
-

--- a/src/components/Stepper/Stepper.const.ts
+++ b/src/components/Stepper/Stepper.const.ts
@@ -1,6 +1,5 @@
 import type { StepperSize, StepStatus, StepperOrientation } from './Stepper.types';
 
-// ── Defaults ─────────────────────────────────────────────
 export const DEFAULT_ORIENTATION: StepperOrientation = 'horizontal';
 export const DEFAULT_SIZE: StepperSize = 'md';
 export const DEFAULT_SHOW_NUMBERS = true;
@@ -21,7 +20,6 @@ export const LAST_STEP_OFFSET = 1;
 export const OVERFLOW_LEFT_LABEL = 'Previous steps';
 export const OVERFLOW_RIGHT_LABEL = 'More steps';
 
-// ── Icon SVGs ────────────────────────────────────────────
 export const CHECK_ICON_SIZE = 16;
 export const CHECK_ICON_VIEWBOX = '0 0 24 24';
 export const CHECK_ICON_POINTS = '20 6 9 17 4 12';
@@ -29,66 +27,77 @@ export const CHECK_ICON_POINTS = '20 6 9 17 4 12';
 export const ERROR_ICON_SIZE = 16;
 export const ERROR_ICON_VIEWBOX = '0 0 24 24';
 
-// ── Base classes ─────────────────────────────────────────
 export const STEPPER_BASE_CLASSES = 'Bear-Stepper';
-export const STEPPER_HORIZONTAL_CLASSES = 'flex w-full items-center';
-export const STEPPER_VERTICAL_CLASSES = 'flex flex-col';
+export const STEPPER_HORIZONTAL_CLASSES = 'bear-flex bear-w-full bear-items-center';
+export const STEPPER_VERTICAL_CLASSES = 'bear-flex bear-flex-col';
 
-// ── Step wrapper classes ─────────────────────────────────
-export const STEP_WRAPPER_HORIZONTAL = 'relative shrink-0 flex-1 min-w-[80px]';
-export const STEP_WRAPPER_HORIZONTAL_WINDOW = 'relative min-w-[5rem] max-w-[9rem] shrink-0';
-export const STEP_WRAPPER_VERTICAL = 'relative flex items-start pb-8 last:pb-0';
+export const STEP_WRAPPER_HORIZONTAL = 'bear-relative bear-shrink-0 bear-flex-1 bear-min-w-[80px]';
+export const STEP_WRAPPER_HORIZONTAL_WINDOW = 'bear-relative bear-min-w-[5rem] bear-max-w-[9rem] bear-shrink-0';
+export const STEP_WRAPPER_VERTICAL = 'bear-relative bear-flex bear-items-start bear-pb-8 last:bear-pb-0';
 
-// ── Step indicator classes ───────────────────────────────
-export const STEP_INDICATOR_BASE = 'Bear-Stepper__indicator flex items-center justify-center rounded-full font-medium transition-all';
+export const STEP_INDICATOR_BASE =
+  'Bear-Stepper__indicator bear-flex bear-items-center bear-justify-center bear-rounded-full bear-font-medium bear-transition-all';
 
 export const STEP_INDICATOR_SIZES: Record<StepperSize, string> = {
-  sm: 'w-6 h-6 text-xs',
-  md: 'w-8 h-8 text-sm',
-  lg: 'w-10 h-10 text-base',
+  sm: 'bear-w-6 bear-h-6 bear-text-xs',
+  md: 'bear-w-8 bear-h-8 bear-text-sm',
+  lg: 'bear-w-10 bear-h-10 bear-text-base',
 };
 
 export const STEP_STATUS_CLASSES: Record<StepStatus, { indicator: string; label: string }> = {
   pending: {
-    indicator: 'bg-gray-200 dark:bg-zinc-700 text-gray-500 dark:text-gray-400',
-    label: 'text-gray-500 dark:text-gray-400',
+    indicator:
+      'bear-bg-gray-200 dark:bear-bg-zinc-700 bear-text-gray-600 dark:bear-text-gray-400',
+    label: 'bear-text-gray-500 dark:bear-text-gray-400',
   },
   active: {
-    indicator: 'bg-primary-500 text-white shadow-lg shadow-primary-500/30',
-    label: 'text-gray-900 dark:text-white font-medium',
+    indicator:
+      'bear-bg-primary-500 dark:bear-bg-primary-500 bear-text-white bear-shadow-lg bear-shadow-primary-500/30',
+    label: 'bear-text-gray-900 dark:bear-text-white bear-font-medium',
   },
   completed: {
-    indicator: 'bg-green-500 text-white',
-    label: 'text-gray-700 dark:text-gray-300',
+    indicator: 'bear-bg-green-500 bear-text-white',
+    label: 'bear-text-gray-700 dark:bear-text-gray-300',
   },
   error: {
-    indicator: 'bg-red-500 text-white',
-    label: 'text-red-500 dark:text-red-400',
+    indicator: 'bear-bg-red-500 bear-text-white',
+    label: 'bear-text-red-500 dark:bear-text-red-400',
   },
 };
 
-// ── Connector classes ────────────────────────────────────
-export const CONNECTOR_BASE = 'Bear-Stepper__connector absolute transition-colors';
-export const CONNECTOR_HORIZONTAL = 'top-4 h-0.5 -translate-y-1/2';
-export const CONNECTOR_VERTICAL = 'left-4 top-8 w-0.5 h-full -translate-x-1/2';
+export const CONNECTOR_BASE = 'Bear-Stepper__connector bear-absolute bear-transition-colors';
+export const CONNECTOR_HORIZONTAL = 'bear-top-4 bear-h-0.5 -bear-translate-y-1/2';
+export const CONNECTOR_VERTICAL = 'bear-left-4 bear-top-8 bear-w-0.5 bear-h-full -bear-translate-x-1/2';
 
 export const CONNECTOR_STYLES = {
   solid: '',
-  dashed: 'border-dashed',
+  dashed: 'bear-border-dashed',
 };
 
 export const CONNECTOR_STATUS = {
-  pending: 'bg-gray-200 dark:bg-zinc-700',
-  completed: 'bg-green-500',
+  pending: 'bear-bg-gray-200 dark:bear-bg-zinc-700',
+  completed: 'bear-bg-green-500',
 };
 
-// ── Step label classes ───────────────────────────────────
-export const STEP_LABEL_BASE = 'Bear-Stepper__label transition-colors';
+export const STEP_LABEL_BASE = 'Bear-Stepper__label bear-transition-colors';
 export const STEP_LABEL_SIZES: Record<StepperSize, { label: string; description: string }> = {
-  sm: { label: 'text-xs', description: 'text-[10px]' },
-  md: { label: 'text-sm', description: 'text-xs' },
-  lg: { label: 'text-base', description: 'text-sm' },
+  sm: { label: 'bear-text-xs', description: 'bear-text-[10px]' },
+  md: { label: 'bear-text-sm', description: 'bear-text-xs' },
+  lg: { label: 'bear-text-base', description: 'bear-text-sm' },
 };
 
-// ── Step description ─────────────────────────────────────
-export const STEP_DESCRIPTION_CLASSES = 'text-gray-500 dark:text-gray-400 mt-0.5';
+export const STEP_DESCRIPTION_CLASSES = 'bear-text-gray-500 dark:bear-text-gray-400 bear-mt-0.5';
+
+export const STEP_CLICKABLE_CLASSES = 'bear-cursor-pointer hover:bear-scale-105';
+export const CONNECTOR_HORIZONTAL_LAYOUT =
+  'Bear-Stepper__connector bear-flex-1 bear-self-center bear-mx-1 bear-h-0.5 bear-min-w-[12px] bear-transition-colors';
+export const CONNECTOR_DASHED_CLASSES = 'bear-border-t-2 bear-border-dashed bear-bg-transparent';
+export const STEP_CONTENT_BASE = 'Bear-Stepper__content bear-flex bear-shrink-0';
+export const STEP_CONTENT_ALTERNATIVE = 'bear-flex-col bear-items-center';
+export const STEP_CONTENT_INLINE = 'bear-items-center bear-gap-2';
+export const STEP_LABEL_ALTERNATIVE = 'bear-text-center bear-mt-2 bear-whitespace-nowrap';
+export const STEP_LABEL_INLINE = 'bear-whitespace-nowrap';
+export const STEP_VERTICAL_INDICATOR_WRAP = 'bear-flex-shrink-0 bear-mr-4';
+export const STEP_VERTICAL_BODY = 'bear-flex-1 bear-pt-0.5';
+export const STEP_VERTICAL_CONTENT = 'bear-mt-4';
+export const STEP_OVERFLOW_ROOT = 'Bear-Stepper__overflow bear-shrink-0';

--- a/src/components/Stepper/Stepper.tsx
+++ b/src/components/Stepper/Stepper.tsx
@@ -34,6 +34,18 @@ import {
   STEP_LABEL_BASE,
   STEP_LABEL_SIZES,
   STEP_DESCRIPTION_CLASSES,
+  STEP_CLICKABLE_CLASSES,
+  CONNECTOR_HORIZONTAL_LAYOUT,
+  CONNECTOR_DASHED_CLASSES,
+  STEP_CONTENT_BASE,
+  STEP_CONTENT_ALTERNATIVE,
+  STEP_CONTENT_INLINE,
+  STEP_LABEL_ALTERNATIVE,
+  STEP_LABEL_INLINE,
+  STEP_VERTICAL_INDICATOR_WRAP,
+  STEP_VERTICAL_BODY,
+  STEP_VERTICAL_CONTENT,
+  STEP_OVERFLOW_ROOT,
 } from './Stepper.const';
 import { resolveStepStatus, resolveIndicatorContent } from './Stepper.utils';
 
@@ -138,7 +150,7 @@ export const Stepper = forwardRef<HTMLDivElement, StepperProps>(
             STEP_INDICATOR_BASE,
             sizeConfig,
             statusClasses.indicator,
-            clickable && !step.disabled && 'cursor-pointer hover:scale-105'
+            clickable && !step.disabled && STEP_CLICKABLE_CLASSES
           )}
           onClick={() => {
             if (clickable && !step.disabled && onStepClick) {
@@ -160,10 +172,9 @@ export const Stepper = forwardRef<HTMLDivElement, StepperProps>(
         return (
           <div
             className={cn(
-              'Bear-Stepper__connector flex-1 self-center mx-1',
-              'h-0.5 min-w-[12px] transition-colors',
+              CONNECTOR_HORIZONTAL_LAYOUT,
               isCompleted ? CONNECTOR_STATUS.completed : CONNECTOR_STATUS.pending,
-              connectorStyle === 'dashed' && 'border-t-2 border-dashed bg-transparent'
+              connectorStyle === 'dashed' && CONNECTOR_DASHED_CLASSES
             )}
           />
         );
@@ -175,7 +186,7 @@ export const Stepper = forwardRef<HTMLDivElement, StepperProps>(
             CONNECTOR_BASE,
             CONNECTOR_VERTICAL,
             isCompleted ? CONNECTOR_STATUS.completed : CONNECTOR_STATUS.pending,
-            connectorStyle === 'dashed' && 'border-t-2 border-dashed bg-transparent'
+            connectorStyle === 'dashed' && CONNECTOR_DASHED_CLASSES
           )}
         />
       );
@@ -211,9 +222,14 @@ export const Stepper = forwardRef<HTMLDivElement, StepperProps>(
     const renderStepContent = (step: Step, index: number) => {
       const status = resolveStepStatus(step, index, activeStep);
       return (
-        <div className={cn('Bear-Stepper__content flex shrink-0', alternativeLabel ? 'flex-col items-center' : 'items-center gap-2')}>
+        <div
+          className={cn(
+            STEP_CONTENT_BASE,
+            alternativeLabel ? STEP_CONTENT_ALTERNATIVE : STEP_CONTENT_INLINE
+          )}
+        >
           {renderIndicator(step, index, status)}
-          <div className={cn(alternativeLabel && 'text-center mt-2', 'whitespace-nowrap')}>
+          <div className={cn(alternativeLabel ? STEP_LABEL_ALTERNATIVE : STEP_LABEL_INLINE)}>
             {renderLabel(step, status)}
           </div>
         </div>
@@ -224,17 +240,19 @@ export const Stepper = forwardRef<HTMLDivElement, StepperProps>(
       const status = resolveStepStatus(step, index, activeStep);
       return (
         <>
-          <div className="flex-shrink-0 mr-4">{renderIndicator(step, index, status)}</div>
-          <div className="flex-1 pt-0.5">
+          <div className={STEP_VERTICAL_INDICATOR_WRAP}>{renderIndicator(step, index, status)}</div>
+          <div className={STEP_VERTICAL_BODY}>
             {renderLabel(step, status)}
-            {step.content && status === 'active' && <div className="mt-4">{step.content}</div>}
+            {step.content && status === 'active' && (
+              <div className={STEP_VERTICAL_CONTENT}>{step.content}</div>
+            )}
           </div>
         </>
       );
     };
 
     const renderOverflowColumn = (hidden: number[], side: 'left' | 'right') => (
-      <div key={`overflow-${side}`} className="Bear-Stepper__overflow shrink-0">
+      <div key={`overflow-${side}`} className={STEP_OVERFLOW_ROOT}>
         <Dropdown
           placement="bottom-start"
           closeOnSelect


### PR DESCRIPTION
## Summary
- Kit light-mode fixes for StatCard and Stepper (`bear-*` prefixes)
- Portal companion banners for Ink and Forge Calendar
- Version **1.2.9** — Bear CI publishes on merge to `main`

## Test plan
- [x] Feature PR #56 (kit light-mode) already on `release/1.2.9`
- [x] Companion banners PR #57 merged into `release/1.2.9`
- [ ] Confirm npm `@forgedevstack/bear@1.2.9` after publish job


Made with [Cursor](https://cursor.com)