### PR TITLE
fix(modal): stack dialog above backdrop blur (FORGE-84)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Bear UI will be documented in this file.
 
+## [1.3.0] - Unreleased
+
+### Fixed
+
+- **Modal** — dialog panel stacks above the Backdrop blur (FORGE-84).
+
 ## [1.2.9] - 2026-08-14
 
 ### Fixed

--- a/src/components/Backdrop/Backdrop.const.ts
+++ b/src/components/Backdrop/Backdrop.const.ts
@@ -1,5 +1,6 @@
 export const BACKDROP_ROOT_CLASS = 'Bear-Backdrop';
 export const BACKDROP_DEFAULT_Z_INDEX = 11000;
+export const BACKDROP_NESTED_Z_INDEX = 0;
 export const BACKDROP_DEFAULT_TRANSITION_MS = 200;
 export const BACKDROP_BASE_CLASSES = 'bear-fixed bear-inset-0 bear-flex bear-items-center bear-justify-center bear-transition-opacity';
 export const BACKDROP_VISIBLE_CLASSES = 'bear-opacity-100 bear-pointer-events-auto';

--- a/src/components/Backdrop/index.ts
+++ b/src/components/Backdrop/index.ts
@@ -1,2 +1,3 @@
 export { Backdrop } from './Backdrop';
 export type { BackdropProps } from './Backdrop.types';
+export { BACKDROP_NESTED_Z_INDEX, BACKDROP_DEFAULT_Z_INDEX } from './Backdrop.const';

--- a/src/components/Modal/Modal.const.ts
+++ b/src/components/Modal/Modal.const.ts
@@ -1,7 +1,9 @@
 import type { ModalSize } from './Modal.types';
 
-// Z-index
-export const MODAL_Z_INDEX = 50;
+export const MODAL_Z_INDEX = 11000;
+export const MODAL_ROOT_CLASSES =
+  'Bear-Modal bear-fixed bear-inset-0 bear-z-[11000] bear-flex bear-items-center bear-justify-center bear-p-4';
+export const MODAL_PANEL_STACK_CLASSES = 'bear-relative bear-z-[1]';
 
 // Size classes
 export const MODAL_SIZE_CLASSES: Record<ModalSize, string> = {

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import { cn, resolveBearId, useBearId } from '@utils';
 import { CloseIcon } from '../Icon/icons/navigation';
 import { Backdrop } from '../Backdrop';
+import { BACKDROP_NESTED_Z_INDEX } from '../Backdrop/Backdrop.const';
 import type { ModalProps } from './Modal.types';
 import {
   MODAL_SIZE_CLASSES,
@@ -12,6 +13,8 @@ import {
   MODAL_CLOSE_CLASSES,
   MODAL_BODY_CLASSES,
   MODAL_FOOTER_CLASSES,
+  MODAL_ROOT_CLASSES,
+  MODAL_PANEL_STACK_CLASSES,
 } from './Modal.const';
 
 /**
@@ -79,7 +82,7 @@ export const Modal: FC<ModalProps> = (props) => {
 
   const modalContent = (
     <div
-      className="Bear-Modal bear-fixed bear-inset-0 bear-z-[11000] bear-flex bear-items-center bear-justify-center bear-p-4"
+      className={MODAL_ROOT_CLASSES}
       data-testid={testId}
       id={domId}
     >
@@ -88,6 +91,7 @@ export const Modal: FC<ModalProps> = (props) => {
           open={isOpen}
           keepMounted={keepMounted}
           blur
+          zIndex={BACKDROP_NESTED_Z_INDEX}
           className="Bear-Modal__backdrop"
           onClick={closeBackdropClick ? () => onClose() : undefined}
         />
@@ -99,6 +103,7 @@ export const Modal: FC<ModalProps> = (props) => {
         aria-labelledby={title ? `${domId}-title` : undefined}
         className={cn(
           'Bear-Modal__container',
+          MODAL_PANEL_STACK_CLASSES,
           MODAL_CONTAINER_CLASSES,
           MODAL_SIZE_CLASSES[size],
           className


### PR DESCRIPTION
## Summary
- Modal panel now stacks above a nested Backdrop (`z-index: 0`) so the dialog is no longer under the blur.
- Jira: FORGE-84 · Linear: GAT-79
- Target: `release/1.3.0`. Do not merge to main / do not publish.

## Test plan
- [ ] Open Modal in light and dark — panel is sharp, page behind is blurred
- [ ] Backdrop click and Escape still close the modal


Made with [Cursor](https://cursor.com)