### PR TITLE
fix(drawer): stack panel above backdrop blur (FORGE-85)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Bear UI will be documented in this file.
 
+## [1.3.0] - Unreleased
+
+### Fixed
+
+- **Drawer** — panel stacks above the Backdrop blur (FORGE-85).
+
 ## [1.2.9] - 2026-08-14
 
 ### Fixed

--- a/src/components/Drawer/Drawer.const.ts
+++ b/src/components/Drawer/Drawer.const.ts
@@ -4,6 +4,9 @@ type DrawerSide = NonNullable<DrawerProps['side']>;
 type DrawerSize = NonNullable<DrawerProps['size']>;
 
 export const DRAWER_ANIMATION_MS = 300;
+export const DRAWER_BACKDROP_Z_INDEX = 0;
+export const DRAWER_ROOT_CLASSES = 'Bear-Drawer bear-fixed bear-inset-0 bear-z-[11000]';
+export const DRAWER_PANEL_Z_CLASS = 'bear-z-[1]';
 
 export const SIZE_CLASSES: Record<DrawerSide, Record<DrawerSize, string>> = {
   left: {

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -7,6 +7,9 @@ import { Backdrop } from '../Backdrop';
 import type { DrawerProps } from './Drawer.types';
 import {
   DRAWER_ANIMATION_MS,
+  DRAWER_BACKDROP_Z_INDEX,
+  DRAWER_ROOT_CLASSES,
+  DRAWER_PANEL_Z_CLASS,
   SIZE_CLASSES,
   POSITION_CLASSES,
   TRANSFORM_OPEN,
@@ -91,11 +94,12 @@ export const Drawer: FC<DrawerProps> = ({
   if (!isMounted) return null;
 
   const drawerContent = (
-    <div id={domId} data-testid={testId} className="Bear-Drawer bear-fixed bear-inset-0 bear-z-[11000]">
+    <div id={domId} data-testid={testId} className={DRAWER_ROOT_CLASSES}>
       <Backdrop
         open={hasOpened && !isClosing}
         keepMounted
         blur
+        zIndex={DRAWER_BACKDROP_Z_INDEX}
         transitionDuration={DRAWER_ANIMATION_MS}
         className="Bear-Drawer__backdrop"
         onClick={closeOnBackdrop ? () => onClose() : undefined}
@@ -107,6 +111,7 @@ export const Drawer: FC<DrawerProps> = ({
         aria-labelledby={title ? `${domId}-title` : undefined}
         className={cn(
           'Bear-Drawer__panel',
+          DRAWER_PANEL_Z_CLASS,
           'bear-absolute bear-bg-white dark:bear-bg-neutral-900 bear-shadow-2xl',
           'bear-border-neutral-200 dark:bear-border-neutral-700',
           'bear-flex bear-flex-col bear-overflow-hidden',


### PR DESCRIPTION
## Summary
- Drawer panel now stacks above a nested Backdrop so the drawer is no longer under the blur.
- Jira: FORGE-85 · Linear: GAT-77
- Target: `release/1.3.0`. Do not merge to main / do not publish.

## Test plan
- [ ] Open Drawer left/right — panel is sharp, page behind is blurred
- [ ] Backdrop click and Escape still close the drawer


Made with [Cursor](https://cursor.com)