### PR TITLE
fix(toast,snackbar): light-mode surfaces (FORGE-86)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Bear UI will be documented in this file.
 
+## [1.3.0] - Unreleased
+
+### Fixed
+
+- **Toast / Snackbar** — light-mode surfaces use theme tokens instead of missing utilities / page-white (FORGE-86).
+
 ## [1.2.9] - 2026-08-14
 
 ### Fixed

--- a/src/components/Snackbar/Snackbar.const.ts
+++ b/src/components/Snackbar/Snackbar.const.ts
@@ -1,3 +1,5 @@
+import type { SnackbarSeverity } from './Snackbar.types';
+
 export const SNACKBAR_ROOT_CLASS = 'Bear-Snackbar';
 
 export const SNACKBAR_DEFAULT_AUTO_HIDE_MS = 6000;
@@ -21,7 +23,15 @@ export const SNACKBAR_SIZE_PADDING: Record<'sm' | 'md' | 'lg', string> = {
 };
 
 export const SNACKBAR_SURFACE_CLASSES =
-  'bear-bg-[var(--bear-bg-primary)] bear-text-[var(--bear-text-primary)]';
+  'bear-shadow-xl';
+
+export const SNACKBAR_SEVERITY_MODIFIER: Record<SnackbarSeverity, string> = {
+  default: `${SNACKBAR_ROOT_CLASS}--default`,
+  success: `${SNACKBAR_ROOT_CLASS}--success`,
+  info: `${SNACKBAR_ROOT_CLASS}--info`,
+  warning: `${SNACKBAR_ROOT_CLASS}--warning`,
+  error: `${SNACKBAR_ROOT_CLASS}--error`,
+};
 
 export const SNACKBAR_COUNTDOWN_TICK_MS = 50;
 

--- a/src/components/Snackbar/Snackbar.tsx
+++ b/src/components/Snackbar/Snackbar.tsx
@@ -14,6 +14,7 @@ import {
   SNACKBAR_ROOT_CLASS,
   SNACKBAR_SIZE_PADDING,
   SNACKBAR_SURFACE_CLASSES,
+  SNACKBAR_SEVERITY_MODIFIER,
   SNACKBAR_Z_INDEX,
 } from './Snackbar.const';
 import { useSnackbar } from './hooks/useSnackbar';
@@ -125,6 +126,7 @@ export const Snackbar = (props: SnackbarProps) => {
         background="transparent"
         className={cn(
           SNACKBAR_ROOT_CLASS,
+          SNACKBAR_SEVERITY_MODIFIER[severity],
           SNACKBAR_SURFACE_CLASSES,
           'bear-fixed bear-flex bear-flex-col bear-overflow-hidden',
           'bear-border bear-border-[var(--bear-border-default)]',

--- a/src/components/Toast/Toast.const.ts
+++ b/src/components/Toast/Toast.const.ts
@@ -1,4 +1,4 @@
-import type { ToastSeverity } from './Toast.types';
+import type { ToastSeverity, ToastPosition } from './Toast.types';
 import {
   BEAR_ARIA_LIVE_BY_SEVERITY,
   BEAR_ARIA_ROLE_BY_SEVERITY,
@@ -21,3 +21,23 @@ export const TOAST_ARIA_ROLE: Record<ToastSeverity, 'status' | 'alert'> = {
 };
 
 export const TOAST_EXIT_MS = 200;
+
+export const TOAST_SEVERITY_MODIFIER: Record<ToastSeverity, string> = {
+  success: `${T_O_A_S_T_ROOT_CLASS}--success`,
+  info: `${T_O_A_S_T_ROOT_CLASS}--info`,
+  warning: `${T_O_A_S_T_ROOT_CLASS}--warning`,
+  error: `${T_O_A_S_T_ROOT_CLASS}--error`,
+};
+
+export const TOAST_POSITION_CLASSES: Record<ToastPosition, string> = {
+  'top-left': 'bear-top-4 bear-left-4',
+  'top-center': 'bear-top-4 bear-left-1/2 bear-transform bear--translate-x-1/2',
+  'top-right': 'bear-top-4 bear-right-4',
+  'bottom-left': 'bear-bottom-4 bear-left-4',
+  'bottom-center': 'bear-bottom-4 bear-left-1/2 bear-transform bear--translate-x-1/2',
+  'bottom-right': 'bear-bottom-4 bear-right-4',
+};
+
+export const TOAST_ITEM_CLASSES =
+  'bear-flex bear-items-start bear-gap-3 bear-p-4 bear-rounded-lg bear-shadow-lg bear-min-w-[300px] bear-max-w-[400px] bear-transition-all bear-duration-200';
+

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -10,6 +10,9 @@ import type {
 import {
   T_O_A_S_T_ROOT_CLASS,
   TOAST_EXIT_MS,
+  TOAST_ITEM_CLASSES,
+  TOAST_POSITION_CLASSES,
+  TOAST_SEVERITY_MODIFIER,
 } from './Toast.const';
 import { cn, generateBearId, getBearLiveRegionProps } from '@utils';
 
@@ -51,21 +54,9 @@ const CloseIcon = () => (
   </svg>
 );
 
-const SEVERITY_STYLES: Record<ToastSeverity, string> = {
-  success: 'bear-bg-green-500 bear-text-white',
-  info: 'bear-bg-blue-500 bear-text-white',
-  warning: 'bear-bg-amber-500 bear-text-white',
-  error: 'bear-bg-red-500 bear-text-white',
-};
+const SEVERITY_STYLES: Record<ToastSeverity, string> = TOAST_SEVERITY_MODIFIER;
 
-const POSITION_STYLES: Record<ToastPosition, string> = {
-  'top-left': 'bear-top-4 bear-left-4',
-  'top-center': 'bear-top-4 bear-left-1/2 bear-transform bear--translate-x-1/2',
-  'top-right': 'bear-top-4 bear-right-4',
-  'bottom-left': 'bear-bottom-4 bear-left-4',
-  'bottom-center': 'bear-bottom-4 bear-left-1/2 bear-transform bear--translate-x-1/2',
-  'bottom-right': 'bear-bottom-4 bear-right-4',
-};
+const POSITION_STYLES: Record<ToastPosition, string> = TOAST_POSITION_CLASSES;
 
 // Context
 const ToastContext = createContext<ToastContextValue | null>(null);
@@ -151,8 +142,7 @@ const ToastItem: FC<ToastProps & { onRemove: () => void }> = ({
       onMouseLeave={pauseOnHover ? () => setIsPaused(false) : undefined}
       className={cn(
         T_O_A_S_T_ROOT_CLASS,
-        'bear-flex bear-items-start bear-gap-3 bear-p-4 bear-rounded-lg bear-shadow-lg bear-min-w-[300px] bear-max-w-[400px]',
-        'bear-transition-all bear-duration-200',
+        TOAST_ITEM_CLASSES,
         isExiting ? 'bear-opacity-0 bear-translate-x-2' : 'bear-opacity-100 bear-translate-x-0',
         SEVERITY_STYLES[severity],
         className
@@ -185,7 +175,7 @@ const ToastItem: FC<ToastProps & { onRemove: () => void }> = ({
         <button
           type="button"
           onClick={handleClose}
-          className="bear-flex-shrink-0 bear-p-1 bear-rounded hover:bear-bg-white/20 bear-transition-colors bear-bg-transparent bear-border-none bear-cursor-pointer"
+          className="bear-flex-shrink-0 bear-p-1 bear-rounded hover:bear-bg-black/10 dark:hover:bear-bg-white/20 bear-transition-colors bear-bg-transparent bear-border-none bear-cursor-pointer"
           aria-label="Close"
         >
           <CloseIcon />

--- a/src/styles/_feedback.css
+++ b/src/styles/_feedback.css
@@ -1,0 +1,87 @@
+.Bear-Toast--success {
+  background-color: var(--bear-success-50);
+  color: var(--bear-success-700);
+  border: 1px solid var(--bear-success-500);
+}
+
+.Bear-Toast--info {
+  background-color: var(--bear-info-50);
+  color: var(--bear-info-700);
+  border: 1px solid var(--bear-info-500);
+}
+
+.Bear-Toast--warning {
+  background-color: var(--bear-warning-50);
+  color: var(--bear-warning-700);
+  border: 1px solid var(--bear-warning-500);
+}
+
+.Bear-Toast--error {
+  background-color: var(--bear-danger-50);
+  color: var(--bear-danger-700);
+  border: 1px solid var(--bear-danger-500);
+}
+
+.bear-dark .Bear-Toast--success,
+.dark .Bear-Toast--success {
+  background-color: var(--bear-success-500);
+  color: #ffffff;
+  border-color: var(--bear-success-500);
+}
+
+.bear-dark .Bear-Toast--info,
+.dark .Bear-Toast--info {
+  background-color: var(--bear-info-500);
+  color: #ffffff;
+  border-color: var(--bear-info-500);
+}
+
+.bear-dark .Bear-Toast--warning,
+.dark .Bear-Toast--warning {
+  background-color: var(--bear-warning-500);
+  color: #ffffff;
+  border-color: var(--bear-warning-500);
+}
+
+.bear-dark .Bear-Toast--error,
+.dark .Bear-Toast--error {
+  background-color: var(--bear-danger-500);
+  color: #ffffff;
+  border-color: var(--bear-danger-500);
+}
+
+.Bear-Snackbar {
+  background-color: var(--bear-bg-secondary);
+  color: var(--bear-text-primary);
+}
+
+.Bear-Snackbar--success {
+  background-color: var(--bear-success-50);
+  border-color: var(--bear-success-500);
+}
+
+.Bear-Snackbar--info {
+  background-color: var(--bear-info-50);
+  border-color: var(--bear-info-500);
+}
+
+.Bear-Snackbar--warning {
+  background-color: var(--bear-warning-50);
+  border-color: var(--bear-warning-500);
+}
+
+.Bear-Snackbar--error {
+  background-color: var(--bear-danger-50);
+  border-color: var(--bear-danger-500);
+}
+
+.bear-dark .Bear-Snackbar--success,
+.dark .Bear-Snackbar--success,
+.bear-dark .Bear-Snackbar--info,
+.dark .Bear-Snackbar--info,
+.bear-dark .Bear-Snackbar--warning,
+.dark .Bear-Snackbar--warning,
+.bear-dark .Bear-Snackbar--error,
+.dark .Bear-Snackbar--error {
+  background-color: var(--bear-bg-secondary);
+}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1,6 +1,7 @@
 @import './_base.css';
 @import './_buttons.css';
 @import './_alerts.css';
+@import './_feedback.css';
 @import './_message-list.css';
 @import './_effects.css';
 @import './_marquee.css';


### PR DESCRIPTION
## Summary
- Toast severity colors now use shipped CSS tokens (`_feedback.css`) instead of missing `bear-bg-green-500` utilities.
- Snackbar uses `--bear-bg-secondary` plus severity tints so it is visible on a light page.
- Jira: FORGE-86 · Linear: GAT-78
- Target: `release/1.3.0`. Do not merge to main / do not publish.

## Test plan
- [ ] Fire success/info/warning/error toasts in light mode — readable surfaces
- [ ] Open Snackbar in light mode — not white-on-white
- [ ] Dark mode still readable


Made with [Cursor](https://cursor.com)