### PR TITLE
fix(signpad): capture signature strokes (FORGE-87)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Bear UI will be documented in this file.
 
+## [1.3.0] - Unreleased
+
+### Fixed
+
+- **SignPad** — pointer capture for drawing; overlay chrome no longer blocks strokes; resize/theme no longer wipe the signature (FORGE-87).
+
 ## [1.2.9] - 2026-08-14
 
 ### Fixed

--- a/src/components/SignPad/SignPad.const.ts
+++ b/src/components/SignPad/SignPad.const.ts
@@ -31,3 +31,8 @@ export const SIGN_PAD_X_MARK_CLASSES = 'bear-absolute bear-bottom-6 bear-left-4 
 
 export const SIGN_PAD_ACTIONS_CLASSES = 'bear-flex bear-gap-2 bear-justify-end';
 
+export const SIGN_PAD_OVERLAY_POINTER_CLASS = 'bear-pointer-events-none';
+export const SIGN_PAD_TRANSPARENT_FILL = 'rgba(0,0,0,0)';
+export const SIGN_PAD_EMPTY_SIZE = 0;
+export const SIGN_PAD_UNIT_SCALE = 1;
+

--- a/src/components/SignPad/SignPad.tsx
+++ b/src/components/SignPad/SignPad.tsx
@@ -19,7 +19,15 @@ import {
   SIGN_PAD_STROKE_DARK,
   SIGN_PAD_BG_LIGHT,
   SIGN_PAD_BG_DARK,
+  SIGN_PAD_OVERLAY_POINTER_CLASS,
+  SIGN_PAD_EMPTY_SIZE,
 } from './SignPad.const';
+import {
+  fillCanvasBackground,
+  getCanvasPoint,
+  strokeCanvasSegment,
+  syncCanvasSize,
+} from './SignPad.utils';
 
 /**
  * SignPad - Digital signature capture component
@@ -58,6 +66,7 @@ export const SignPad: FC<SignPadProps> = (props) => {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const lastPointRef = useRef<{ x: number; y: number } | null>(null);
   const isDrawingRef = useRef(false);
+  const hasSignatureRef = useRef(false);
 
   const [hasSignature, setHasSignature] = useState(false);
   const [isDarkMode, setIsDarkMode] = useState(false);
@@ -77,10 +86,8 @@ export const SignPad: FC<SignPadProps> = (props) => {
 
   const fillCanvas = useCallback(() => {
     const canvas = canvasRef.current;
-    const ctx = canvas?.getContext('2d');
-    if (!canvas || !ctx) return;
-    ctx.fillStyle = backgroundColor === 'transparent' ? 'rgba(0,0,0,0)' : backgroundColor;
-    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    if (!canvas) return;
+    fillCanvasBackground(canvas, backgroundColor);
   }, [backgroundColor]);
 
   useEffect(() => {
@@ -92,11 +99,8 @@ export const SignPad: FC<SignPadProps> = (props) => {
       const rect = wrapper.getBoundingClientRect();
       const w = widthProp ?? Math.round(rect.width);
       const h = heightProp;
-      if (canvas.width !== w || canvas.height !== h) {
-        canvas.width = w;
-        canvas.height = h;
-        fillCanvas();
-      }
+      if (w <= SIGN_PAD_EMPTY_SIZE || h <= SIGN_PAD_EMPTY_SIZE) return;
+      syncCanvasSize(canvas, w, h, backgroundColor, hasSignatureRef.current);
     };
 
     syncSize();
@@ -104,9 +108,10 @@ export const SignPad: FC<SignPadProps> = (props) => {
     const ro = new ResizeObserver(syncSize);
     ro.observe(wrapper);
     return () => ro.disconnect();
-  }, [widthProp, heightProp, fillCanvas]);
+  }, [widthProp, heightProp, backgroundColor]);
 
   useEffect(() => {
+    if (hasSignatureRef.current) return;
     fillCanvas();
   }, [fillCanvas, isDarkMode]);
 
@@ -122,55 +127,37 @@ export const SignPad: FC<SignPadProps> = (props) => {
     };
   }, [disabled, readOnly]);
 
-  const getPointFromEvent = useCallback((e: React.MouseEvent | React.TouchEvent): { x: number; y: number } => {
+  const getPointFromEvent = useCallback((e: React.PointerEvent<HTMLCanvasElement>): { x: number; y: number } => {
     const canvas = canvasRef.current;
-    if (!canvas) return { x: 0, y: 0 };
-    const rect = canvas.getBoundingClientRect();
-    const scaleX = canvas.width / rect.width;
-    const scaleY = canvas.height / rect.height;
-
-    if ('touches' in e) {
-      const touch = e.touches[0];
-      return {
-        x: (touch.clientX - rect.left) * scaleX,
-        y: (touch.clientY - rect.top) * scaleY,
-      };
-    }
-    return {
-      x: (e.clientX - rect.left) * scaleX,
-      y: (e.clientY - rect.top) * scaleY,
-    };
+    if (!canvas) return { x: SIGN_PAD_EMPTY_SIZE, y: SIGN_PAD_EMPTY_SIZE };
+    return getCanvasPoint(canvas, e.clientX, e.clientY);
   }, []);
 
-  const startDrawing = useCallback((e: React.MouseEvent | React.TouchEvent) => {
+  const startDrawing = useCallback((e: React.PointerEvent<HTMLCanvasElement>) => {
     if (disabled || readOnly) return;
+    e.currentTarget.setPointerCapture(e.pointerId);
     const point = getPointFromEvent(e);
     isDrawingRef.current = true;
     lastPointRef.current = point;
   }, [disabled, readOnly, getPointFromEvent]);
 
-  const draw = useCallback((e: React.MouseEvent | React.TouchEvent) => {
+  const draw = useCallback((e: React.PointerEvent<HTMLCanvasElement>) => {
     if (!isDrawingRef.current || disabled || readOnly) return;
     const canvas = canvasRef.current;
-    const ctx = canvas?.getContext('2d');
     const lp = lastPointRef.current;
-    if (!canvas || !ctx || !lp) return;
+    if (!canvas || !lp) return;
 
     const point = getPointFromEvent(e);
-    ctx.beginPath();
-    ctx.moveTo(lp.x, lp.y);
-    ctx.lineTo(point.x, point.y);
-    ctx.strokeStyle = strokeColor;
-    ctx.lineWidth = strokeWidth;
-    ctx.lineCap = 'round';
-    ctx.lineJoin = 'round';
-    ctx.stroke();
-
+    strokeCanvasSegment(canvas, lp, point, strokeColor, strokeWidth);
     lastPointRef.current = point;
+    hasSignatureRef.current = true;
     setHasSignature(true);
   }, [disabled, readOnly, strokeColor, strokeWidth, getPointFromEvent]);
 
-  const stopDrawing = useCallback(() => {
+  const stopDrawing = useCallback((e?: React.PointerEvent<HTMLCanvasElement>) => {
+    if (e && e.currentTarget.hasPointerCapture(e.pointerId)) {
+      e.currentTarget.releasePointerCapture(e.pointerId);
+    }
     if (isDrawingRef.current) {
       const canvas = canvasRef.current;
       if (canvas && onChange) {
@@ -186,8 +173,9 @@ export const SignPad: FC<SignPadProps> = (props) => {
     const canvas = canvasRef.current;
     const ctx = canvas?.getContext('2d');
     if (!canvas || !ctx) return;
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.clearRect(SIGN_PAD_EMPTY_SIZE, SIGN_PAD_EMPTY_SIZE, canvas.width, canvas.height);
     fillCanvas();
+    hasSignatureRef.current = false;
     setHasSignature(false);
     onChange?.(null);
   }, [fillCanvas, onChange]);
@@ -225,23 +213,20 @@ export const SignPad: FC<SignPadProps> = (props) => {
           ref={canvasRef}
           className="Bear-SignPad__canvas bear-block bear-rounded-lg bear-w-full bear-touch-none"
           style={{ height: heightProp }}
-          onMouseDown={startDrawing}
-          onMouseMove={draw}
-          onMouseUp={stopDrawing}
-          onMouseLeave={stopDrawing}
-          onTouchStart={startDrawing}
-          onTouchMove={draw}
-          onTouchEnd={stopDrawing}
+          onPointerDown={startDrawing}
+          onPointerMove={draw}
+          onPointerUp={stopDrawing}
+          onPointerCancel={stopDrawing}
         />
 
         {!hasSignature && (
-          <div className={cn('Bear-SignPad__placeholder', SIGN_PAD_PLACEHOLDER_CLASSES)}>
+          <div className={cn('Bear-SignPad__placeholder', SIGN_PAD_PLACEHOLDER_CLASSES, SIGN_PAD_OVERLAY_POINTER_CLASS)}>
             {placeholder}
           </div>
         )}
 
-        <div className={cn('Bear-SignPad__line', SIGN_PAD_LINE_CLASSES)} />
-        <span className={cn('Bear-SignPad__x-mark', SIGN_PAD_X_MARK_CLASSES)}>×</span>
+        <div className={cn('Bear-SignPad__line', SIGN_PAD_LINE_CLASSES, SIGN_PAD_OVERLAY_POINTER_CLASS)} />
+        <span className={cn('Bear-SignPad__x-mark', SIGN_PAD_X_MARK_CLASSES, SIGN_PAD_OVERLAY_POINTER_CLASS)}>×</span>
       </div>
 
       {(showClear || showSave) && (

--- a/src/components/SignPad/SignPad.utils.ts
+++ b/src/components/SignPad/SignPad.utils.ts
@@ -1,0 +1,80 @@
+import {
+  SIGN_PAD_EMPTY_SIZE,
+  SIGN_PAD_TRANSPARENT_FILL,
+  SIGN_PAD_UNIT_SCALE,
+} from './SignPad.const';
+
+export const resolveCanvasFill = (backgroundColor: string): string =>
+  backgroundColor === 'transparent' ? SIGN_PAD_TRANSPARENT_FILL : backgroundColor;
+
+export const fillCanvasBackground = (
+  canvas: HTMLCanvasElement,
+  backgroundColor: string,
+): void => {
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return;
+  ctx.fillStyle = resolveCanvasFill(backgroundColor);
+  ctx.fillRect(SIGN_PAD_EMPTY_SIZE, SIGN_PAD_EMPTY_SIZE, canvas.width, canvas.height);
+};
+
+export const syncCanvasSize = (
+  canvas: HTMLCanvasElement,
+  width: number,
+  height: number,
+  backgroundColor: string,
+  preserve: boolean,
+): void => {
+  if (canvas.width === width && canvas.height === height) {
+    return;
+  }
+
+  const shouldPreserve =
+    preserve && canvas.width > SIGN_PAD_EMPTY_SIZE && canvas.height > SIGN_PAD_EMPTY_SIZE;
+  const snapshot = document.createElement('canvas');
+  if (shouldPreserve) {
+    snapshot.width = canvas.width;
+    snapshot.height = canvas.height;
+    snapshot.getContext('2d')?.drawImage(canvas, SIGN_PAD_EMPTY_SIZE, SIGN_PAD_EMPTY_SIZE);
+  }
+
+  canvas.width = width;
+  canvas.height = height;
+  fillCanvasBackground(canvas, backgroundColor);
+
+  if (shouldPreserve) {
+    canvas.getContext('2d')?.drawImage(snapshot, SIGN_PAD_EMPTY_SIZE, SIGN_PAD_EMPTY_SIZE, width, height);
+  }
+};
+
+export const getCanvasPoint = (
+  canvas: HTMLCanvasElement,
+  clientX: number,
+  clientY: number,
+): { x: number; y: number } => {
+  const rect = canvas.getBoundingClientRect();
+  const scaleX = rect.width === SIGN_PAD_EMPTY_SIZE ? SIGN_PAD_UNIT_SCALE : canvas.width / rect.width;
+  const scaleY = rect.height === SIGN_PAD_EMPTY_SIZE ? SIGN_PAD_UNIT_SCALE : canvas.height / rect.height;
+  return {
+    x: (clientX - rect.left) * scaleX,
+    y: (clientY - rect.top) * scaleY,
+  };
+};
+
+export const strokeCanvasSegment = (
+  canvas: HTMLCanvasElement,
+  from: { x: number; y: number },
+  to: { x: number; y: number },
+  strokeColor: string,
+  strokeWidth: number,
+): void => {
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return;
+  ctx.beginPath();
+  ctx.moveTo(from.x, from.y);
+  ctx.lineTo(to.x, to.y);
+  ctx.strokeStyle = strokeColor;
+  ctx.lineWidth = strokeWidth;
+  ctx.lineCap = 'round';
+  ctx.lineJoin = 'round';
+  ctx.stroke();
+};


### PR DESCRIPTION
## Summary
- SignPad uses pointer capture; line/x-mark overlays no longer steal events.
- Canvas resize/theme fill preserves an in-progress signature instead of wiping it.
- Jira: FORGE-87 · Linear: GAT-80
- Target: `release/1.3.0`. Do not merge to main / do not publish.

## Test plan
- [ ] Draw with mouse on /components/sign-pad — stroke appears
- [ ] Draw with touch / trackpad — stroke appears
- [ ] Clear still resets; resize does not erase a signature


Made with [Cursor](https://cursor.com)