### PR TITLE
fix: resolve bear-icons from npm so CI can typecheck (FORGE-141)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "1.3.2",
       "license": "MIT",
       "dependencies": {
-        "@forgedevstack/anvil": "^1.0.0",
-        "@forgedevstack/bear-icons": "^1.0.0"
+        "@forgedevstack/anvil": "^1.0.0"
       },
       "devDependencies": {
         "@forgedevstack/aerocraft": "^1.0.4",
+        "@forgedevstack/bear-icons": "^1.0.1",
         "@types/node": "^22.10.7",
         "@types/react": "^18.3.18",
         "@types/react-dom": "^18.3.5",
@@ -34,26 +34,12 @@
         "vite-plugin-dts": "^4.4.0",
         "vitest": "^2.1.8"
       },
+      "optionalDependencies": {
+        "@forgedevstack/bear-icons": "^1.0.1"
+      },
       "peerDependencies": {
         "react": ">=18.0.0",
         "react-dom": ">=18.0.0"
-      }
-    },
-    "../bear-icons": {
-      "name": "@forgedevstack/bear-icons",
-      "version": "1.0.0",
-      "license": "MIT",
-      "devDependencies": {
-        "@types/node": "^22.10.7",
-        "@types/react": "^18.3.18",
-        "@vitejs/plugin-react": "^4.3.4",
-        "react": "^18.3.1",
-        "typescript": "^5.7.3",
-        "vite": "^6.0.7",
-        "vite-plugin-dts": "^4.4.0"
-      },
-      "peerDependencies": {
-        "react": ">=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -958,8 +944,14 @@
       }
     },
     "node_modules/@forgedevstack/bear-icons": {
-      "resolved": "../bear-icons",
-      "link": true
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@forgedevstack/bear-icons/-/bear-icons-1.0.1.tgz",
+      "integrity": "sha512-UW0TxQTURbXND02nwC/+DOh54bweuLjFSRq9riMXfoKDbOfP/uOQ59/giLJC0FAVgl+AVNMtDfi5h9wGmVkl2g==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18.0.0"
+      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "react-dom": ">=18.0.0"
   },
   "devDependencies": {
+    "@forgedevstack/bear-icons": "^1.0.1",
     "@forgedevstack/aerocraft": "^1.0.4",
     "@types/node": "^22.10.7",
     "@types/react": "^18.3.18",


### PR DESCRIPTION
## Summary
- `@forgedevstack/bear-icons` is a **devDependency** (`^1.0.1`) so this repo always installs it for `tsc` / publish / portal builds
- Lockfile now resolves **1.0.1 from the npm registry** instead of a local `../bear-icons` path that does not exist in CI
- Icons stay **optional** for consumers (`optionalDependencies`)

Fixes https://github.com/yaghobieh/bear/issues/88 (FORGE-141). Unblocks Bear **1.3.2** publish.

## Test plan
- [x] `npm ci` installs `@forgedevstack/bear-icons@1.0.1` from the registry
- [x] `tsc` is clean
- [ ] GitHub Actions publish job builds and publishes `@forgedevstack/bear@1.3.2`
- [ ] Portal job (`npm run portal:build`) succeeds