### PR TITLE
feat: npx @forgedevstack/bear installer CLI (FORGE-148)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Bear UI will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- **CLI** — `npx @forgedevstack/bear` shows a Bear banner and installs into a new Vite app or an existing folder (FORGE-148).
+
 ## [1.3.2] - 2026-08-28
 
 ### Added

--- a/bin/bear.mjs
+++ b/bin/bear.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { createInterface } from 'node:readline/promises';
+import { stdin as input, stdout as output } from 'node:process';
+import { join } from 'node:path';
+
+const PINK = '\x1b[38;2;234;10;142m';
+const RESET = '\x1b[0m';
+const BOLD = '\x1b[1m';
+
+const BANNER = `
+${PINK}${BOLD}
+      /\\     /\\
+     {  \`---'  }
+     {  O   O  }
+      ~~> V <~~
+       \\  ^  /
+        |___|
+         BEAR
+${RESET}${PINK}  React UI · npx @forgedevstack/bear${RESET}
+`;
+
+const PACKAGES = [
+  { id: 'bear', name: '@forgedevstack/bear', label: 'Bear UI (components)' },
+  { id: 'icons', name: '@forgedevstack/bear-icons', label: 'Bear Icons' },
+  { id: 'grid', name: '@forgedevstack/grid-table', label: 'Grid Table' },
+];
+
+const ask = async (rl, question, fallback) => {
+  const raw = await rl.question(`${PINK}${question}${RESET} `);
+  const value = raw.trim();
+  return value.length ? value : fallback;
+};
+
+const pickPackages = async (rl) => {
+  console.log('\nWhat should we install?');
+  PACKAGES.forEach((pkg, index) => {
+    console.log(`  ${index + 1}) ${pkg.label}  (${pkg.name})`);
+  });
+  const raw = await ask(rl, 'Numbers (comma) or "all" [all]:', 'all');
+  if (raw === 'all') {
+    return PACKAGES.map((pkg) => pkg.name);
+  }
+  const ids = raw.split(',').map((part) => Number(part.trim()));
+  return PACKAGES.filter((_, index) => ids.includes(index + 1)).map((pkg) => pkg.name);
+};
+
+const runInstall = (cwd, names) => {
+  if (!names.length) {
+    return;
+  }
+  const result = spawnSync('npm', ['install', ...names], { cwd, stdio: 'inherit' });
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+};
+
+const writeStarter = (dir) => {
+  mkdirSync(join(dir, 'src'), { recursive: true });
+  writeFileSync(join(dir, 'package.json'), `${JSON.stringify({
+    name: dir.split('/').pop() || 'bear-app',
+    private: true,
+    type: 'module',
+    scripts: { dev: 'vite', build: 'vite build' },
+  }, null, 2)}\n`);
+  writeFileSync(join(dir, 'index.html'), `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Bear</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>
+`);
+  writeFileSync(join(dir, 'src/main.tsx'), `import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { BearProvider } from '@forgedevstack/bear';
+import '@forgedevstack/bear/styles.css';
+import { App } from './App';
+
+createRoot(document.getElementById('root')).render(
+  <StrictMode>
+    <BearProvider>
+      <App />
+    </BearProvider>
+  </StrictMode>,
+);
+`);
+  writeFileSync(join(dir, 'src/App.tsx'), `import { Button, Typography } from '@forgedevstack/bear';
+
+export const App = () => (
+  <main>
+    <Typography variant="h3">Bear</Typography>
+    <Button>Get started</Button>
+  </main>
+);
+`);
+  writeFileSync(join(dir, 'vite.config.ts'), `import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({ plugins: [react()] });
+`);
+};
+
+const main = async () => {
+  process.stdout.write(BANNER);
+  const rl = createInterface({ input, output });
+  const mode = await ask(rl, 'New project or existing folder? [new/existing]:', 'new');
+  const names = await pickPackages(rl);
+
+  if (mode.startsWith('e')) {
+    const folder = await ask(rl, 'Project folder [.]:', '.');
+    const cwd = folder === '.' ? process.cwd() : join(process.cwd(), folder);
+    if (!existsSync(cwd)) {
+      console.error('Folder not found.');
+      process.exit(1);
+    }
+    rl.close();
+    runInstall(cwd, names);
+    return;
+  }
+
+  const projectName = await ask(rl, 'Project name [bear-app]:', 'bear-app');
+  const dir = join(process.cwd(), projectName);
+  if (existsSync(dir)) {
+    console.error('Folder already exists.');
+    process.exit(1);
+  }
+  rl.close();
+  writeStarter(dir);
+  runInstall(dir, ['react', 'react-dom', 'vite', '@vitejs/plugin-react', ...names]);
+  console.log(`\n${PINK}Created ${projectName}${RESET}\n  cd ${projectName} && npm run dev\n`);
+};
+
+main();

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,7 +6,7 @@ import reactHooks from 'eslint-plugin-react-hooks';
 // Import order convention: put @utils, @hooks, @context imports LAST in the block (see .cursor rules).
 
 export default [
-  { ignores: ['dist/**', '**/*.kiln.*', '.kiln/**', 'portal/**', 'src/postcss/**'] },
+  { ignores: ['dist/**', '**/*.kiln.*', '.kiln/**', 'portal/**', 'src/postcss/**', 'bin/**'] },
   js.configs.recommended,
   {
     files: ['**/*.ts', '**/*.tsx'],

--- a/package.json
+++ b/package.json
@@ -46,8 +46,12 @@
     "./postcss": "./dist/postcss/bear-plugin.cjs"
   },
   "files": [
-    "dist"
+    "dist",
+    "bin"
   ],
+  "bin": {
+    "bear": "./bin/bear.mjs"
+  },
   "scripts": {
     "dev": "vite build --watch",
     "build": "tsc && vite build && npm run build:css && npm run build:modules",


### PR DESCRIPTION
## Summary
- Adds `bin/bear.mjs` so **`npx @forgedevstack/bear`** runs an installer
- ASCII Bear banner, then **new project vs existing folder**
- Choose Bear UI, Bear Icons, and/or Grid Table
- New projects get a minimal Vite + React + `BearProvider` starter
- Zero extra production dependencies on the UI package

Jira: FORGE-148 (epic FORGE-142)

Note: `npx i @bear` is not a valid npm command. After this ships, the command is `npx @forgedevstack/bear`.

## Test plan
- [ ] `node bin/bear.mjs` prints the banner
- [ ] New project path writes files and runs `npm install`
- [ ] Existing folder path installs selected packages only
- [ ] `package.json` `bin.bear` points at `./bin/bear.mjs`